### PR TITLE
fix: resolve sidebar folders through XDG user dirs

### DIFF
--- a/src/models/bookmarkmodel.cpp
+++ b/src/models/bookmarkmodel.cpp
@@ -1,6 +1,7 @@
 #include "models/bookmarkmodel.h"
 #include <QDir>
 #include <QFileInfo>
+#include <QStandardPaths>
 #include <QUrl>
 
 namespace {
@@ -174,7 +175,7 @@ BookmarkModel::Bookmark BookmarkModel::makeBookmark(const QString &rawPath) cons
 {
     QString expanded = expandPath(rawPath);
     QString name = bookmarkDisplayName(expanded);
-    return {name, expanded, iconForPath(name.toLower())};
+    return {name, expanded, iconForPath(expanded, name.toLower())};
 }
 
 QString BookmarkModel::expandPath(const QString &path)
@@ -187,8 +188,29 @@ QString BookmarkModel::expandPath(const QString &path)
     return path;
 }
 
-QString BookmarkModel::iconForPath(const QString &name)
+QString BookmarkModel::iconForPath(const QString &path, const QString &name)
 {
+    // Match the XDG user dirs first: on a localised system the folder is named
+    // "Imagens" or "Documentos", which the English name table below misses.
+    static const QVector<QPair<QStandardPaths::StandardLocation, QString>> xdgIcons = {
+        {QStandardPaths::HomeLocation, QStringLiteral("go-home")},
+        {QStandardPaths::DocumentsLocation, QStringLiteral("folder-documents")},
+        {QStandardPaths::DownloadLocation, QStringLiteral("folder-download")},
+        {QStandardPaths::PicturesLocation, QStringLiteral("folder-pictures")},
+        {QStandardPaths::MusicLocation, QStringLiteral("folder-music")},
+        {QStandardPaths::MoviesLocation, QStringLiteral("folder-videos")},
+        {QStandardPaths::DesktopLocation, QStringLiteral("user-desktop")},
+    };
+
+    if (!path.isEmpty()) {
+        const QString cleaned = QDir::cleanPath(path);
+        for (const auto &entry : xdgIcons) {
+            const QString resolved = QStandardPaths::writableLocation(entry.first);
+            if (!resolved.isEmpty() && QDir::cleanPath(resolved) == cleaned)
+                return entry.second;
+        }
+    }
+
     static const QMap<QString, QString> icons = {
         {"home", "go-home"},
         {"documents", "folder-documents"},

--- a/src/models/bookmarkmodel.h
+++ b/src/models/bookmarkmodel.h
@@ -43,6 +43,6 @@ private:
 
     QList<Bookmark> m_bookmarks;
     static QString expandPath(const QString &path);
-    static QString iconForPath(const QString &name);
+    static QString iconForPath(const QString &path, const QString &name);
     Bookmark makeBookmark(const QString &path) const;
 };

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -1877,6 +1877,28 @@ QString FileSystemModel::homePath() const
     return QDir::homePath();
 }
 
+// Resolves a well-known folder through the XDG user dirs so the sidebar points
+// at the real directory on localised systems. Falls back to home when the key
+// is unknown or the platform has nothing configured.
+QString FileSystemModel::standardPath(const QString &key) const
+{
+    static const QHash<QString, QStandardPaths::StandardLocation> locations = {
+        {QStringLiteral("desktop"), QStandardPaths::DesktopLocation},
+        {QStringLiteral("documents"), QStandardPaths::DocumentsLocation},
+        {QStringLiteral("downloads"), QStandardPaths::DownloadLocation},
+        {QStringLiteral("music"), QStandardPaths::MusicLocation},
+        {QStringLiteral("pictures"), QStandardPaths::PicturesLocation},
+        {QStringLiteral("videos"), QStandardPaths::MoviesLocation},
+    };
+
+    const auto it = locations.constFind(key.toLower());
+    if (it == locations.constEnd())
+        return QDir::homePath();
+
+    const QString path = QStandardPaths::writableLocation(*it);
+    return path.isEmpty() ? QDir::homePath() : path;
+}
+
 QVariantList FileSystemModel::pathSuggestions(const QString &input, int limit) const
 {
     QVariantList suggestions;

--- a/src/models/filesystemmodel.h
+++ b/src/models/filesystemmodel.h
@@ -71,6 +71,7 @@ public:
     Q_INVOKABLE QVariantList allInstalledApps() const;
     Q_INVOKABLE bool setFilePermissions(const QString &path, int ownerAccess, int groupAccess, int otherAccess);
     Q_INVOKABLE QString homePath() const;
+    Q_INVOKABLE QString standardPath(const QString &key) const;
     Q_INVOKABLE QVariantList pathSuggestions(const QString &input, int limit = 8) const;
 
     // Tests need a predictable "rowCount is correct right after setRootPath()"

--- a/src/qml/components/Sidebar.qml
+++ b/src/qml/components/Sidebar.qml
@@ -120,8 +120,8 @@ Rectangle {
                         if (model.name === "Recents") return ""
                         if (model.name === "Trash") return root.trashPath
                         if (model.name === "Network") return "network:///"
-                        if (model.name === "Pictures") return home + "/Pictures"
-                        if (model.name === "Downloads") return home + "/Downloads"
+                        if (model.name === "Pictures") return fsModel.standardPath("pictures")
+                        if (model.name === "Downloads") return fsModel.standardPath("downloads")
                         return ""
                     }
 

--- a/src/services/configmanager.cpp
+++ b/src/services/configmanager.cpp
@@ -83,6 +83,25 @@ QStringList iconSearchDirs()
     return searchDirs;
 }
 
+// Default bookmarks follow the XDG user dirs, so they keep working on systems
+// where the folders are localised (Documentos, Imagens, ...). Entries that
+// don't resolve to a real directory are dropped instead of shipping a
+// bookmark that opens an empty view.
+QStringList defaultBookmarkPaths()
+{
+    QStringList paths = {
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
+        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
+        QStandardPaths::writableLocation(QStandardPaths::PicturesLocation),
+        QDir::homePath() + QStringLiteral("/Projects"),
+    };
+
+    paths.removeAll(QString());
+    paths.removeDuplicates();
+    paths.removeIf([](const QString &path) { return !QFileInfo(path).isDir(); });
+    return paths;
+}
+
 } // namespace
 
 QMap<QString, QString> ConfigManager::s_defaultShortcuts = {
@@ -209,7 +228,7 @@ void ConfigManager::setDefaults()
     m_sidebarPosition = "left";
     m_sidebarWidth = 200;
     m_sidebarVisible = true;
-    m_bookmarks = {"~/Documents", "~/Downloads", "~/Pictures", "~/Projects"};
+    m_bookmarks = defaultBookmarkPaths();
     m_radiusSmall = 4;
     m_radiusMedium = 8;
     m_radiusLarge = 12;

--- a/tests/tst_configmanager.cpp
+++ b/tests/tst_configmanager.cpp
@@ -78,10 +78,20 @@ private slots:
 
     void testDefaultBookmarks()
     {
+        // Defaults drop entries that aren't real directories, so create one of
+        // the standard folders first. Without it the list could come back empty
+        // and the assertions below would pass without checking anything.
+        const QString pictures =
+            QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+        QVERIFY(!pictures.isEmpty());
+        QVERIFY(QDir().mkpath(pictures));
+
         QTemporaryDir dir;
         ConfigManager mgr(dir.path() + "/config.toml");
 
         const QStringList bookmarks = mgr.bookmarks();
+        QVERIFY(!bookmarks.isEmpty());
+        QVERIFY(bookmarks.contains(pictures));
 
         // Defaults resolve through the XDG user dirs rather than hardcoded
         // English names, so every entry is an absolute path that exists.
@@ -89,11 +99,6 @@ private slots:
             QVERIFY(!path.startsWith(QLatin1Char('~')));
             QVERIFY(QFileInfo(path).isDir());
         }
-
-        const QString pictures =
-            QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-        if (QFileInfo(pictures).isDir())
-            QVERIFY(bookmarks.contains(pictures));
     }
 
     void testDefaultShortcuts()

--- a/tests/tst_configmanager.cpp
+++ b/tests/tst_configmanager.cpp
@@ -1,6 +1,7 @@
 #include <QTest>
 #include <QTemporaryDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include "services/configmanager.h"
@@ -80,8 +81,19 @@ private slots:
         QTemporaryDir dir;
         ConfigManager mgr(dir.path() + "/config.toml");
 
-        QStringList bookmarks = mgr.bookmarks();
-        QVERIFY(bookmarks.size() >= 1);
+        const QStringList bookmarks = mgr.bookmarks();
+
+        // Defaults resolve through the XDG user dirs rather than hardcoded
+        // English names, so every entry is an absolute path that exists.
+        for (const QString &path : bookmarks) {
+            QVERIFY(!path.startsWith(QLatin1Char('~')));
+            QVERIFY(QFileInfo(path).isDir());
+        }
+
+        const QString pictures =
+            QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+        if (QFileInfo(pictures).isDir())
+            QVERIFY(bookmarks.contains(pictures));
     }
 
     void testDefaultShortcuts()

--- a/tests/tst_filesystemmodel.cpp
+++ b/tests/tst_filesystemmodel.cpp
@@ -1049,6 +1049,21 @@ private slots:
         QCOMPARE(suggestions.size(), 2);
     }
 
+    void testStandardPathFollowsXdgUserDirs()
+    {
+        FileSystemModel model;
+
+        QCOMPARE(model.standardPath("pictures"),
+                 QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
+        QCOMPARE(model.standardPath("downloads"),
+                 QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
+
+        // Keys are case insensitive, and anything unknown falls back to home
+        QCOMPARE(model.standardPath("PICTURES"),
+                 QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
+        QCOMPARE(model.standardPath("not-a-folder"), QDir::homePath());
+    }
+
 private:
     // Helper to set permissions without a FileSystemModel instance
     void model_setPermissionsHelper(const QString &path, int ownerAccess, int groupAccess, int otherAccess)


### PR DESCRIPTION
On a system with localised user dirs the sidebar points at folders that don't exist.

My home is pt_BR, so the folders are `Documentos`, `Imagens` and so on. Quick Access and the default bookmarks are built from hardcoded English names, so I end up with entries called Documents, Pictures and Projects that open an empty view. Downloads also shows up twice, once from Quick Access and once from the bookmarks.

The two places doing it:

- `Sidebar.qml` builds the Quick Access paths as `home + "/Pictures"` and `home + "/Downloads"`
- `ConfigManager::setDefaults()` seeds `{"~/Documents", "~/Downloads", "~/Pictures", "~/Projects"}`

## What this changes

- New `FileSystemModel::standardPath(key)` resolves a well known folder through `QStandardPaths`, which reads `~/.config/user-dirs.dirs`. Quick Access uses it instead of string concatenation.
- Default bookmarks come from `QStandardPaths` too, and entries whose target is not a real directory are dropped. That also covers `~/Projects`, which has no XDG equivalent and now simply isn't added when the folder doesn't exist.
- `BookmarkModel::iconForPath()` matches the resolved path against the XDG locations before falling back to the English name table, otherwise a folder named `Imagens` loses the pictures icon.

Behaviour on an English system is unchanged, since `QStandardPaths` returns `~/Documents`, `~/Pictures` and friends there.

## Two things worth flagging

Dropping bookmarks that don't resolve is a small behaviour change: on a fresh home with no Documents or Pictures you get fewer defaults instead of defaults that open nothing. Happy to drop that part if you'd rather keep them.

The Quick Access labels are still the English strings from the ListModel. I left those alone since the app has no translation layer, and only the target path was actually broken.

## Testing

Added `testStandardPathFollowsXdgUserDirs` to `tst_filesystemmodel`, and tightened `testDefaultBookmarks` in `tst_configmanager` to assert the defaults are absolute paths that exist.

17 of the 18 test binaries pass. `tst_fileoperations` fails on `testTrashHelpersForHomePath`, but it fails identically on a clean checkout of `main` here, so it looks unrelated to this change.

Also ran the built binary to confirm the sidebar now lists `Documentos` and `Projetos` and opens the right folders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quick-access folders now follow your system’s standard directory settings.
  - Bookmark icons more accurately reflect recognized folders such as Documents, Downloads, Pictures, Music, Videos, and Desktop.
  - Default bookmarks are created dynamically from available folders.

- **Bug Fixes**
  - Removed invalid or unavailable default bookmark locations.

- **Tests**
  - Added coverage for standard folder resolution and valid default bookmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->