### PR TITLE
fix: start breadcrumbs at Home instead of walking real ancestors

### DIFF
--- a/src/qml/components/Breadcrumb.qml
+++ b/src/qml/components/Breadcrumb.qml
@@ -155,13 +155,7 @@ Item {
                     if (root.isRecentsView) return [{ label: "Recents", fullPath: "" }]
                     if (!root.path || root.path === "/") return []
 
-                    var result = fileOps.breadcrumbSegments(root.path)
-                    const homePath = fsModel.homePath()
-                    for (var i = 0; i < result.length; ++i) {
-                        if (result[i].fullPath === homePath)
-                            result[i].label = "Home"
-                    }
-                    return result
+                    return fileOps.breadcrumbSegments(root.path)
                 }
 
                 delegate: Row {

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -513,7 +513,20 @@ QVariantList buildBreadcrumbs(const QString &path)
         return segments;
 
     QString accumulated;
-    const QStringList parts = normalized.split('/', Qt::SkipEmptyParts);
+    QStringList parts = normalized.split('/', Qt::SkipEmptyParts);
+
+    // Anything inside the user's home starts at a single "Home" crumb. Walking
+    // the real ancestors instead would render "/home" and "/home/<user>" side
+    // by side, which reads as "home / Home".
+    const QString home = QDir::homePath();
+    if (!home.isEmpty() && home != QStringLiteral("/")
+        && (normalized == home || normalized.startsWith(home + QLatin1Char('/')))) {
+        segments.append(QVariantMap{{QStringLiteral("label"), QStringLiteral("Home")},
+                                    {QStringLiteral("fullPath"), home}});
+        accumulated = home;
+        parts = normalized.mid(home.size()).split('/', Qt::SkipEmptyParts);
+    }
+
     for (const QString &part : parts) {
         accumulated += QStringLiteral("/") + part;
         segments.append(QVariantMap{{QStringLiteral("label"), part},

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -881,6 +881,53 @@ private slots:
         if (finishSpy.isEmpty())
             QVERIFY(finishSpy.wait(10000));
     }
+
+    // --- Breadcrumbs ---
+
+    void testBreadcrumbSegmentsStartAtHome()
+    {
+        FileOperations ops;
+        const QString home = QDir::homePath();
+
+        const QVariantList atHome = ops.breadcrumbSegments(home);
+        QCOMPARE(atHome.size(), 1);
+        QCOMPARE(atHome.at(0).toMap().value("label").toString(), QString("Home"));
+        QCOMPARE(atHome.at(0).toMap().value("fullPath").toString(), home);
+
+        const QVariantList nested = ops.breadcrumbSegments(home + "/Downloads/reports");
+        QCOMPARE(nested.size(), 3);
+        QCOMPARE(nested.at(0).toMap().value("label").toString(), QString("Home"));
+        QCOMPARE(nested.at(0).toMap().value("fullPath").toString(), home);
+        QCOMPARE(nested.at(1).toMap().value("label").toString(), QString("Downloads"));
+        QCOMPARE(nested.at(1).toMap().value("fullPath").toString(), home + "/Downloads");
+        QCOMPARE(nested.at(2).toMap().value("label").toString(), QString("reports"));
+        QCOMPARE(nested.at(2).toMap().value("fullPath").toString(), home + "/Downloads/reports");
+    }
+
+    void testBreadcrumbSegmentsOutsideHomeKeepAncestors()
+    {
+        FileOperations ops;
+
+        const QVariantList segments = ops.breadcrumbSegments("/usr/share");
+        QCOMPARE(segments.size(), 2);
+        QCOMPARE(segments.at(0).toMap().value("label").toString(), QString("usr"));
+        QCOMPARE(segments.at(0).toMap().value("fullPath").toString(), QString("/usr"));
+        QCOMPARE(segments.at(1).toMap().value("label").toString(), QString("share"));
+        QCOMPARE(segments.at(1).toMap().value("fullPath").toString(), QString("/usr/share"));
+    }
+
+    void testBreadcrumbSegmentsDoNotMatchHomePrefix()
+    {
+        FileOperations ops;
+        const QString home = QDir::homePath();
+
+        // A sibling directory that merely starts with the same characters is
+        // not inside home, so it must not collapse to a "Home" crumb.
+        const QVariantList segments = ops.breadcrumbSegments(home + "-backup");
+        QVERIFY(!segments.isEmpty());
+        QVERIFY(segments.at(0).toMap().value("label").toString() != QStringLiteral("Home"));
+        QCOMPARE(segments.last().toMap().value("fullPath").toString(), home + "-backup");
+    }
 };
 
 QTEST_MAIN(TestFileOperations)


### PR DESCRIPTION
Inside the home directory the breadcrumb shows "home" twice.

At `/home/<user>/Downloads` it renders as `home / Home / Downloads`, and at the home directory itself as `home / Home`. Ctrl+L prints the correct `/home/<user>/Downloads`, so only the crumbs are wrong.

`buildBreadcrumbs()` returns every ancestor (`/home`, `/home/<user>`, `/home/<user>/Downloads`), and `Breadcrumb.qml` then relabels the segment whose `fullPath` matches the home path to "Home". The `/home` ancestor above it stays in the list, which is where the duplicate comes from.

This isn't locale specific, every Linux user hits it since the layout is always `/home/<user>`.

## What this changes

Paths under the home directory now start at a single `Home` crumb, built in `buildBreadcrumbs()` next to the existing `Trash` label, so the label arrives correct and the relabel loop in `Breadcrumb.qml` can go. Paths outside home are untouched and keep their full ancestor chain.

I put it in C++ rather than slicing the list in QML because the label is already decided there for trash, and this way it is covered by the test suite.

## Testing

Three cases added to `tst_fileoperations`:

- home itself collapses to a single `Home` crumb, and a nested path gives `Home / Downloads / reports` with the expected `fullPath` on each crumb
- `/usr/share` still yields `usr / share`
- a sibling like `/home/<user>-backup` does not match the home prefix and keeps its own ancestors

`tst_fileoperations` also fails on `testTrashHelpersForHomePath`, but it fails the same way on a clean checkout of `main` here, so that one looks unrelated to this change.

Verified by running the built binary as well, the breadcrumb now reads `Home / Downloads`.

Independent of #3, the two touch different files.
