### PR TITLE
Check against /usr/lib64 when detecting GVFS

### DIFF
--- a/src/services/dependencychecker.cpp
+++ b/src/services/dependencychecker.cpp
@@ -270,12 +270,15 @@ void DependencyChecker::populate()
         buildHints(QStringLiteral("ntfs-3g"))
     });
 
+    const bool gvfsAvailable = hasExecutable(QStringLiteral("gio")) && hasAnyFile({
+        QStringLiteral("/usr/lib/gvfs"),
+        QStringLiteral("/usr/lib64/gvfs"),
+    });
     m_deps.append({
         QStringLiteral("gvfs"),
         QStringLiteral("GVFS backends"),
         QStringLiteral("Connect to remote file systems (SFTP, SMB, WebDAV)."),
-        Kind::Tool, false, hasExecutable(QStringLiteral("gio"))
-            && QDir(QStringLiteral("/usr/lib/gvfs")).exists(),
+        Kind::Tool, false, gvfsAvailable,
         {QStringLiteral("gio")},
         buildHints(QStringLiteral("gvfs"))
     });
@@ -283,6 +286,7 @@ void DependencyChecker::populate()
     const bool gvfsAfcAvailable = hasExecutable(QStringLiteral("gio")) && hasAnyFile({
         QStringLiteral("/usr/share/gvfs/mounts/afc.mount"),
         QStringLiteral("/usr/lib/gvfs/gvfsd-afc"),
+        QStringLiteral("/usr/lib64/gvfs/gvfsd-afc"),
         QStringLiteral("/usr/libexec/gvfsd-afc"),
     });
     m_deps.append({
@@ -302,6 +306,7 @@ void DependencyChecker::populate()
     const bool gvfsGphoto2Available = hasExecutable(QStringLiteral("gio")) && hasAnyFile({
         QStringLiteral("/usr/share/gvfs/mounts/gphoto2.mount"),
         QStringLiteral("/usr/lib/gvfs/gvfsd-gphoto2"),
+        QStringLiteral("/usr/lib64/gvfs/gvfsd-gphoto2"),
         QStringLiteral("/usr/libexec/gvfsd-gphoto2"),
     });
     m_deps.append({


### PR DESCRIPTION
On some systems (for example, my 64-bit Gentoo installation) the shared objects for GVFS will be installed in `/usr/lib64`, causing the dependency check for GVFS to erroneously report that it's unavailable.

This PR adds `/usr/lib64` path to the GVFS family checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GVFS availability detection across systems using `/usr/lib` and `/usr/lib64` locations.
  * Added support for detecting GVFS backends in Flatpak environments.
  * Improved recognition of AFC and gphoto2 backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->