### PR TITLE
Add Nix flake package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+result
 .cache/
 .superpowers/
 CMakeLists.txt.user

--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ The asset name carries the version, so grab the current one from the
 
 The AppImage is fully self-contained — no system Qt installation required.
 
+### Nix (flake)
+
+```bash
+nix run github:soyeb-jim285/hyprfm
+```
+
+Or pull it into a system/home-manager flake:
+
+```nix
+{
+  inputs.hyprfm.url = "github:soyeb-jim285/hyprfm";
+}
+```
+
+then reference `hyprfm.packages.<system>.default` in `environment.systemPackages` / `home.packages`. The package version is parsed straight from `CMakeLists.txt`, so it always tracks the tree it's built from.
+
 ### Build from source
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "quill": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787578571,
+        "narHash": "sha256-N+m9k6WbMMm6GJOxILnEZRiQ0mm3Eu8Se1g0N1ZO0/U=",
+        "owner": "soyeb-jim285",
+        "repo": "quill",
+        "rev": "bc13deae669a1333a0d7bdd991c7015270a16a38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "soyeb-jim285",
+        "repo": "quill",
+        "rev": "bc13deae669a1333a0d7bdd991c7015270a16a38",
+        "type": "github"
+      }
+    },
+    "quill-icons": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776191081,
+        "narHash": "sha256-ezwie0hSHNT0m65dgTgwwh16vfb/vAshcNaccQChnzM=",
+        "owner": "soyeb-jim285",
+        "repo": "quill-icons",
+        "rev": "10db5facf6a560e60d2693ccd1909267ef436002",
+        "type": "github"
+      },
+      "original": {
+        "owner": "soyeb-jim285",
+        "repo": "quill-icons",
+        "rev": "10db5facf6a560e60d2693ccd1909267ef436002",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "quill": "quill",
+        "quill-icons": "quill-icons"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,133 @@
+{
+  description = "HyprFM - a lightweight Qt6/QML file manager for Hyprland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Mirrors the two git submodules pulled in by PKGBUILD's `git submodule
+    # update` (src/qml/icons, src/qml/Quill). Plain flake sources don't fetch
+    # submodules, so they're pinned here instead and copied into place in
+    # postPatch. Pinned to an exact commit rather than a branch: the commits
+    # hyprfm's .gitmodules reference aren't always reachable from quill(-icons)'s
+    # default branch, so tracking the branch can silently resolve to an older
+    # commit. Keep these revs in sync with `git ls-tree main src/qml/Quill
+    # src/qml/icons` whenever the submodules are bumped.
+    quill-icons = {
+      url = "github:soyeb-jim285/quill-icons/10db5facf6a560e60d2693ccd1909267ef436002";
+      flake = false;
+    };
+    quill = {
+      url = "github:soyeb-jim285/quill/bc13deae669a1333a0d7bdd991c7015270a16a38";
+      flake = false;
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      quill-icons,
+      quill,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+
+      # Single source of truth for the version lives in CMakeLists.txt
+      # (`project(hyprfm VERSION x.y.z ...)`) so it never has to be bumped
+      # in two places.
+      version = builtins.head (
+        builtins.match ".*project\\(hyprfm VERSION ([0-9]+\\.[0-9]+\\.[0-9]+).*" (
+          builtins.readFile ./CMakeLists.txt
+        )
+      );
+
+      mkHyprfm =
+        pkgs:
+        pkgs.stdenv.mkDerivation {
+          pname = "hyprfm";
+          inherit version;
+
+          src = self;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+            kdePackages.wrapQtAppsHook
+          ];
+
+          buildInputs = with pkgs; [
+            kdePackages.qtbase
+            kdePackages.qtdeclarative
+            kdePackages.qtsvg
+            kdePackages.qtwayland
+            kdePackages.kwindowsystem
+            glib
+          ];
+
+          # Submodules aren't fetched for a plain flake source; drop the
+          # pinned inputs in where CMake/QML expect them instead.
+          postPatch = ''
+            rm -rf src/qml/icons src/qml/Quill
+            cp -r --no-preserve=mode,ownership ${quill-icons} src/qml/icons
+            cp -r --no-preserve=mode,ownership ${quill} src/qml/Quill
+          '';
+
+          cmakeFlags = [
+            "-DBUILD_TESTS=OFF"
+            "-DHYPRFM_DATA_DIR=${placeholder "out"}/share/hyprfm"
+          ];
+
+          qtWrapperArgs = [
+            "--prefix"
+            "PATH"
+            ":"
+            (pkgs.lib.makeBinPath [
+              pkgs.rsync
+              pkgs.glib # gio
+              pkgs.xdg-utils
+              pkgs.wl-clipboard
+            ])
+          ];
+
+          meta = with pkgs.lib; {
+            description = "A lightweight Qt6/QML file manager for Hyprland";
+            homepage = "https://github.com/soyeb-jim285/hyprfm";
+            license = licenses.mit;
+            mainProgram = "hyprfm";
+            platforms = systems;
+          };
+        };
+    in
+    {
+      packages = forEachSystem (system: {
+        default = self.packages.${system}.hyprfm;
+        hyprfm = mkHyprfm (pkgsFor system);
+      });
+
+      apps = forEachSystem (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.hyprfm}/bin/hyprfm";
+          meta.description = "A lightweight Qt6/QML file manager for Hyprland";
+        };
+      });
+
+      devShells = forEachSystem (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.hyprfm ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary
- Add a `flake.nix` (+ `flake.lock`) that packages HyprFM for Nix, exposing `packages.<system>.{default,hyprfm}`, `apps.<system>.default` (`nix run`), and a `devShells.<system>.default` for local builds
- The package version is parsed directly from `CMakeLists.txt`'s `project(hyprfm VERSION x.y.z ...)` line via `builtins.match`, so there's no separate version to keep in sync
- The `quill-icons` and `Quill` git submodules are pinned as flake inputs (`flake.lock`) and copied into place in `postPatch`, since a bare flake source doesn't fetch submodules
- Document the Nix install path in the README, alongside AUR/Flatpak/.deb/AppImage
- Ignore the `result` build symlink

## Test plan
- [x] `nix flake check --all-systems` passes clean (x86_64-linux, aarch64-linux eval)
- [x] `nix build .#hyprfm` succeeds
- [x] `nix run .` prints `hyprfm 0.5.3`, matching the version in `CMakeLists.txt`
- [x] `nix develop` provides cmake/ninja/pkg-config for manual builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nix flake support for installing and running HyprFM on x86_64 and aarch64 Linux systems.
  * Added packaged application and development-shell outputs for Nix users.
  * Added README instructions for direct installation and integration with system or Home Manager flakes.

* **Chores**
  * Excluded generated `result` files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->