### PR TITLE
fix: normalize legacy file view modes

### DIFF
--- a/src/models/tablistmodel.cpp
+++ b/src/models/tablistmodel.cpp
@@ -117,13 +117,19 @@ TabModel *TabListModel::tabAt(int index) const
 
 void TabListModel::setDefaultViewMode(const QString &mode)
 {
-    if (mode.isEmpty() || m_defaultViewMode == mode)
+    QString normalized = mode;
+    if (normalized == QStringLiteral("list"))
+        normalized = QStringLiteral("detailed");
+    else if (normalized != QStringLiteral("grid") && normalized != QStringLiteral("detailed") && normalized != QStringLiteral("miller"))
+        normalized = QStringLiteral("grid");
+
+    if (normalized.isEmpty() || m_defaultViewMode == normalized)
         return;
-    m_defaultViewMode = mode;
+    m_defaultViewMode = normalized;
     // Apply to tabs still on the built-in default (startup tab before session restore)
     for (TabModel *tab : m_tabs) {
         if (tab->viewMode() == QStringLiteral("grid"))
-            tab->setViewMode(mode);
+            tab->setViewMode(normalized);
     }
 }
 

--- a/src/models/tabmodel.cpp
+++ b/src/models/tabmodel.cpp
@@ -102,8 +102,14 @@ bool TabModel::sortAscending() const { return m_sortAscending; }
 
 void TabModel::setViewMode(const QString &mode)
 {
-    if (m_viewMode != mode) {
-        m_viewMode = mode;
+    QString normalized = mode;
+    if (normalized == QStringLiteral("list"))
+        normalized = QStringLiteral("detailed");
+    else if (normalized != QStringLiteral("grid") && normalized != QStringLiteral("detailed") && normalized != QStringLiteral("miller"))
+        normalized = QStringLiteral("grid");
+
+    if (m_viewMode != normalized) {
+        m_viewMode = normalized;
         emit viewModeChanged();
     }
 }

--- a/src/qml/views/FileViewContainer.qml
+++ b/src/qml/views/FileViewContainer.qml
@@ -6,6 +6,11 @@ Item {
 
     // "grid" | "detailed" | "miller"
     property string viewMode: "grid"
+    readonly property string effectiveViewMode: {
+        if (viewMode === "list" || viewMode === "detailed") return "detailed"
+        if (viewMode === "miller") return "miller"
+        return "grid"
+    }
     property var fileModel: null
     property string currentPath: ""
 
@@ -17,8 +22,8 @@ Item {
     signal sortRequested(string column, bool ascending)
 
     function selectAll() {
-        if (viewMode === "grid") gridView.selectAll()
-        else if (viewMode === "miller") millerView.selectAll()
+        if (effectiveViewMode === "grid") gridView.selectAll()
+        else if (effectiveViewMode === "miller") millerView.selectAll()
         else detailedView.selectAll()
     }
 
@@ -36,7 +41,7 @@ Item {
     FileGridView {
         id: gridView
         anchors.fill: parent
-        visible: root.viewMode === "grid"
+        visible: root.effectiveViewMode === "grid"
         model: visible ? root.fileModel : null
         currentPath: root.currentPath
 
@@ -50,7 +55,7 @@ Item {
     FileDetailedView {
         id: detailedView
         anchors.fill: parent
-        visible: root.viewMode === "detailed"
+        visible: root.effectiveViewMode === "detailed"
         viewModel: visible ? root.fileModel : null
         currentPath: root.currentPath
 
@@ -65,7 +70,7 @@ Item {
     FileMillerView {
         id: millerView
         anchors.fill: parent
-        visible: root.viewMode === "miller"
+        visible: root.effectiveViewMode === "miller"
         fileModel: visible ? root.fileModel : null
         currentPath: root.currentPath
 

--- a/src/services/configmanager.cpp
+++ b/src/services/configmanager.cpp
@@ -336,8 +336,12 @@ void ConfigManager::loadConfig()
             m_iconTheme = QString::fromStdString(*v);
         if (auto v = config["general"]["font_family"].value<std::string>())
             m_fontFamily = QString::fromStdString(*v);
-        if (auto v = config["general"]["default_view"].value<std::string>())
-            m_defaultView = QString::fromStdString(*v);
+        if (auto v = config["general"]["default_view"].value<std::string>()) {
+            QString dv = QString::fromStdString(*v);
+            if (dv == QStringLiteral("list"))
+                dv = QStringLiteral("detailed");
+            m_defaultView = dv;
+        }
         if (auto v = config["general"]["show_hidden"].value<bool>())
             m_showHidden = *v;
         if (auto v = config["general"]["dependency_startup_check"].value<bool>())

--- a/tests/tst_configmanager.cpp
+++ b/tests/tst_configmanager.cpp
@@ -641,7 +641,7 @@ private slots:
         ConfigManager mgr(path);
         QCOMPARE(mgr.theme(), QString("custom"));
         QCOMPARE(mgr.fontFamily(), QString("Inter"));
-        QCOMPARE(mgr.defaultView(), QString("list"));
+        QCOMPARE(mgr.defaultView(), QString("detailed"));
         QCOMPARE(mgr.showHidden(), true);
         QCOMPARE(mgr.sortBy(), QString("size"));
         QCOMPARE(mgr.sortAscending(), false);

--- a/tests/tst_tabmodel.cpp
+++ b/tests/tst_tabmodel.cpp
@@ -154,15 +154,16 @@ private slots:
         QSignalSpy spy(&tab, &TabModel::viewModeChanged);
 
         tab.setViewMode("list");
-        QCOMPARE(tab.viewMode(), QString("list"));
+        QCOMPARE(tab.viewMode(), QString("detailed"));
         QCOMPARE(spy.count(), 1);
 
         tab.setViewMode("detailed");
         QCOMPARE(tab.viewMode(), QString("detailed"));
-        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.count(), 1);
 
         tab.setViewMode("grid");
         QCOMPARE(tab.viewMode(), QString("grid"));
+        QCOMPARE(spy.count(), 2);
     }
 
     void testSortProperties()


### PR DESCRIPTION
This PR makes file view-mode handling consistent across configuration loading, C++ models, and the QML view container.

Previously, the application could receive the legacy list mode or an unsupported value and pass it through without normalization. That could cause the configured view mode and the actual QML view selection to become inconsistent.

## Changes
- Treat the legacy list view mode as an alias for detailed.
- Validate view modes in TabModel and fall back to grid for unsupported values.
- Normalize default view modes in TabListModel.
- Normalize default_view while loading the TOML configuration.
- Add an effective view mode in FileViewContainer.qml so view visibility and selection behavior use the same normalized value.
- Preserve the existing behavior for grid, detailed, and miller modes.

Existing configurations using `default_view = "list"` will continue to work and open the detailed file view. Invalid or unknown view-mode values will safely display the grid view instead of leaving the view state unresolved.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file view mode handling for consistent behavior across the application.
  - Legacy “list” settings are now automatically displayed as “detailed.”
  - Unsupported view mode values now safely fall back to “grid.”
  - Default view settings are normalized when loaded and applied consistently to tabs and file views.
  - Existing supported modes, including “grid,” “detailed,” and “miller,” continue to work as expected.
  - Reapplying the current view mode no longer triggers unnecessary updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->