### PR TITLE
feat: right click on address bar to edit the path

### DIFF
--- a/src/qml/components/Breadcrumb.qml
+++ b/src/qml/components/Breadcrumb.qml
@@ -120,12 +120,15 @@ Item {
         anchors.fill: parent
         visible: !root.editMode
         z: -1
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        acceptedButtons: config.rightClickToEditPath ? Qt.LeftButton | Qt.RightButton : Qt.LeftButton
         onPressed: (event) => {
             if (event.button === Qt.RightButton && config.rightClickToEditPath)
                 root.startEditing()
         }
-        onDoubleClicked: root.startEditing()
+        onDoubleClicked: (mouse) => {
+            if (mouse.button === Qt.LeftButton)
+                root.startEditing()
+        }
     }
 
     // Clickable path segments (display mode)

--- a/src/qml/components/Breadcrumb.qml
+++ b/src/qml/components/Breadcrumb.qml
@@ -114,11 +114,17 @@ Item {
     height: 28
     clip: false
 
-    // Background MouseArea: double-click empty space enters edit mode
+    // Background MouseArea: right click anywhere on the bar (config-gated) or
+    // double click on empty space enters path edit mode with all text selected.
     MouseArea {
         anchors.fill: parent
         visible: !root.editMode
         z: -1
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: (event) => {
+            if (event.button === Qt.RightButton && config.rightClickToEditPath)
+                root.startEditing()
+        }
         onDoubleClicked: root.startEditing()
     }
 

--- a/src/qml/components/SettingsPanel.qml
+++ b/src/qml/components/SettingsPanel.qml
@@ -258,6 +258,7 @@ Window {
         draftFontFamily = ""
         draftIconTheme = defaultIconThemeName
         draftShowHidden = false
+        draftRightClickToEditPath = true
         draftDependencyStartupCheck = true
         draftSidebarVisible = true
         draftHiddenQuickAccess = []

--- a/src/qml/components/SettingsPanel.qml
+++ b/src/qml/components/SettingsPanel.qml
@@ -74,6 +74,7 @@ Window {
     property string draftIconTheme: config.iconTheme
     property bool draftDarkMode: true
     property bool draftShowHidden: currentShowHidden
+    property bool draftRightClickToEditPath: config.rightClickToEditPath
     property bool draftDependencyStartupCheck: config.dependencyStartupCheck
     property bool draftSidebarVisible: currentSidebarVisible
     // Must stay in sync with the quick-access entries in Sidebar.qml.
@@ -301,6 +302,7 @@ Window {
             iconThemeOptions = buildOptions(availableIconThemeValues, draftIconTheme, "Adwaita")
 
             draftShowHidden = currentShowHidden
+            draftRightClickToEditPath = config.rightClickToEditPath
             draftDependencyStartupCheck = config.dependencyStartupCheck
             draftSidebarVisible = currentSidebarVisible
             draftHiddenQuickAccess = config.hiddenQuickAccess
@@ -371,6 +373,7 @@ Window {
             fontFamily: draftFontFamily,
             iconTheme: draftIconTheme,
             showHidden: draftShowHidden,
+            rightClickToEditPath: draftRightClickToEditPath,
             dependencyStartupCheck: draftDependencyStartupCheck,
             sidebarVisible: draftSidebarVisible,
             hiddenQuickAccess: draftHiddenQuickAccess,
@@ -665,6 +668,15 @@ Window {
                 checked: root.draftShowHidden
                 onToggled: (value) => {
                     root.draftShowHidden = value
+                    root.applySettingsNow()
+                }
+            }
+
+            Q.Checkbox {
+                label: "Right click address bar to edit path"
+                checked: root.draftRightClickToEditPath
+                onToggled: (value) => {
+                    root.draftRightClickToEditPath = value
                     root.applySettingsNow()
                 }
             }

--- a/src/services/configmanager.cpp
+++ b/src/services/configmanager.cpp
@@ -279,6 +279,7 @@ void ConfigManager::setDefaults()
     m_fontFamily.clear();
     m_defaultView = "grid";
     m_showHidden = false;
+    m_rightClickToEditPath = true;
     m_sortBy = "name";
     m_sortAscending = true;
     m_rememberSortPerFolder = true;
@@ -346,6 +347,8 @@ void ConfigManager::loadConfig()
             m_defaultView = QString::fromStdString(*v);
         if (auto v = config["general"]["show_hidden"].value<bool>())
             m_showHidden = *v;
+        if (auto v = config["general"]["right_click_to_edit_path"].value<bool>())
+            m_rightClickToEditPath = *v;
         if (auto v = config["general"]["dependency_startup_check"].value<bool>())
             m_dependencyStartupCheck = *v;
         if (auto v = config["general"]["sort_by"].value<std::string>())
@@ -579,6 +582,11 @@ font_family = ""
 default_view = "grid"
 
 show_hidden = false
+
+# Right click anywhere on the address bar enters path edit mode with the
+# whole path selected, just like Ctrl+L. Left clicks on breadcrumb segments
+# still navigate.
+right_click_to_edit_path = true
 
 # Sort order: "name" | "size" | "modified" | "type"
 sort_by = "name"
@@ -817,6 +825,8 @@ QString ConfigManager::iconTheme() const { return m_iconTheme; }
 QString ConfigManager::fontFamily() const { return m_fontFamily; }
 QString ConfigManager::defaultView() const { return m_defaultView; }
 bool ConfigManager::showHidden() const { return m_showHidden; }
+
+bool ConfigManager::rightClickToEditPath() const { return m_rightClickToEditPath; }
 bool ConfigManager::dependencyStartupCheck() const { return m_dependencyStartupCheck; }
 QString ConfigManager::sortBy() const { return m_sortBy; }
 bool ConfigManager::sortAscending() const { return m_sortAscending; }
@@ -954,6 +964,11 @@ void ConfigManager::saveSettings(const QVariantMap &settings)
     if (settings.contains("showHidden")) {
         m_showHidden = settings.value("showHidden").toBool();
         general.insert_or_assign("show_hidden", m_showHidden);
+    }
+
+    if (settings.contains("rightClickToEditPath")) {
+        m_rightClickToEditPath = settings.value("rightClickToEditPath").toBool();
+        general.insert_or_assign("right_click_to_edit_path", m_rightClickToEditPath);
     }
 
     if (settings.contains("dependencyStartupCheck")) {

--- a/src/services/configmanager.h
+++ b/src/services/configmanager.h
@@ -20,6 +20,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(QString fontFamily READ fontFamily NOTIFY configChanged)
     Q_PROPERTY(QString defaultView READ defaultView NOTIFY configChanged)
     Q_PROPERTY(bool showHidden READ showHidden NOTIFY configChanged)
+    Q_PROPERTY(bool rightClickToEditPath READ rightClickToEditPath NOTIFY configChanged)
     Q_PROPERTY(bool dependencyStartupCheck READ dependencyStartupCheck NOTIFY configChanged)
     Q_PROPERTY(QString sortBy READ sortBy NOTIFY configChanged)
     Q_PROPERTY(bool sortAscending READ sortAscending NOTIFY configChanged)
@@ -73,6 +74,9 @@ public:
     QString fontFamily() const;
     QString defaultView() const;
     bool showHidden() const;
+    // Right click on the address bar starts path editing (Ctrl+L behaviour).
+    // Clicking a breadcrumb segment still navigates.
+    bool rightClickToEditPath() const;
     bool dependencyStartupCheck() const;
     QString sortBy() const;
     bool sortAscending() const;
@@ -162,6 +166,7 @@ private:
     QString m_fontFamily;
     QString m_defaultView;
     bool m_showHidden;
+    bool m_rightClickToEditPath;
     bool m_dependencyStartupCheck;
     QString m_sortBy;
     bool m_sortAscending;


### PR DESCRIPTION
Right click anywhere on the address bar opens it in edit mode with the whole path selected, like Ctrl+L. Clicking a breadcrumb segment still navigates.

Adds a `right_click_to_edit_path` setting in config.toml (on by default), with a matching checkbox in Settings > Browsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to enter path editing mode by right-clicking the address bar.
  - Right-click editing is enabled by default and can be toggled in the Layout settings.
  - Double-clicking empty address bar space continues to enter edit mode.
  - The new preference is saved and restored automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->