### PR TITLE
feat(cloud): add background rclone mount service and remote path optimizations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HYPRFM_SOURCES
     services/previewservice.cpp
     services/diskusageservice.cpp
     services/remoteaccessservice.cpp
+    services/rcloneservice.cpp
     services/runtimefeaturesservice.cpp
     services/dependencychecker.cpp
     services/gitstatusservice.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@
 #include "services/metadataextractor.h"
 #include "services/diskusageservice.h"
 #include "services/remoteaccessservice.h"
+#include "services/rcloneservice.h"
 #include "services/runtimefeaturesservice.h"
 #include "services/dependencychecker.h"
 #include "services/gitstatusservice.h"
@@ -509,6 +510,7 @@ int main(int argc, char *argv[])
     MetadataExtractor *metadataExtractor = new MetadataExtractor(&app);
     DiskUsageService *diskUsageService = new DiskUsageService(&app);
     RemoteAccessService *remoteAccessService = new RemoteAccessService(&app);
+    RcloneService *rcloneService = new RcloneService(&app);
     RuntimeFeaturesService *runtimeFeatures = new RuntimeFeaturesService(&app);
     config->setShowWindowControlsDefault(runtimeFeatures->useIntegratedWindowControls());
     GitStatusService *primaryGitService = new GitStatusService(&app);
@@ -602,6 +604,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("metadataExtractor", metadataExtractor);
     engine.rootContext()->setContextProperty("diskUsageService", diskUsageService);
     engine.rootContext()->setContextProperty("remoteAccessService", remoteAccessService);
+    engine.rootContext()->setContextProperty("rcloneService", rcloneService);
     engine.rootContext()->setContextProperty("runtimeFeatures", runtimeFeatures);
     engine.rootContext()->setContextProperty("dependencies", dependencies);
     engine.rootContext()->setContextProperty("sessionState", sessionState);

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -1,4 +1,5 @@
 #include "models/filesystemmodel.h"
+#include "services/cloudmounts.h"
 #include "services/gitstatusservice.h"
 #include "services/xdgtrash.h"
 #include <QLocale>
@@ -288,8 +289,8 @@ QString iconNameForMimeName(const QString &mimeName)
 
 QMimeType mimeTypeForFile(const QString &path)
 {
-    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
-    if (path.startsWith(prefix)) {
+    // Content sniffing on a FUSE mount means a network round trip per entry.
+    if (isCloudMountPath(path)) {
         return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchExtension);
     }
     return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchDefault);
@@ -1355,8 +1356,7 @@ void FileSystemModel::ensurePopulated(const Entry &entry) const
     entry.sizeText = isDir ? QString() : formattedSize(entry.info.size());
     entry.modifiedText = QLocale().toString(entry.info.lastModified(), QLocale::ShortFormat);
 
-    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
-    const bool isRemote = absPath.startsWith(prefix);
+    const bool isRemote = isCloudMountPath(absPath);
 
     if (isRemote) {
         entry.permissionsText = isDir ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
@@ -1573,8 +1573,7 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
     if (isRemoteUri(normalizedPath))
         return remoteFileProperties(normalizedPath);
 
-    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
-    const bool isRemote = normalizedPath.startsWith(prefix);
+    const bool isRemote = isCloudMountPath(normalizedPath);
 
     QFileInfo info(normalizedPath);
     QVariantMap props;

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -288,8 +288,8 @@ QString iconNameForMimeName(const QString &mimeName)
 
 QMimeType mimeTypeForFile(const QString &path)
 {
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
-    if (path.startsWith(mountsDir)) {
+    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
+    if (path.startsWith(prefix)) {
         return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchExtension);
     }
     return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchDefault);
@@ -1355,8 +1355,8 @@ void FileSystemModel::ensurePopulated(const Entry &entry) const
     entry.sizeText = isDir ? QString() : formattedSize(entry.info.size());
     entry.modifiedText = QLocale().toString(entry.info.lastModified(), QLocale::ShortFormat);
 
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
-    const bool isRemote = absPath.startsWith(mountsDir);
+    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
+    const bool isRemote = absPath.startsWith(prefix);
 
     if (isRemote) {
         entry.permissionsText = isDir ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
@@ -1573,8 +1573,8 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
     if (isRemoteUri(normalizedPath))
         return remoteFileProperties(normalizedPath);
 
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
-    const bool isRemote = normalizedPath.startsWith(mountsDir);
+    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
+    const bool isRemote = normalizedPath.startsWith(prefix);
 
     QFileInfo info(normalizedPath);
     QVariantMap props;
@@ -1664,6 +1664,7 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
         props["groupAccess"] = 1;
         props["otherAccess"] = 1;
         props["isExecutable"] = false;
+        props["canEditPermissions"] = false;
     } else {
         // Timestamps
         props["created"] = QLocale().toString(info.birthTime(), QLocale::LongFormat);

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -286,6 +286,20 @@ QString iconNameForMimeName(const QString &mimeName)
     return icon.isEmpty() ? QStringLiteral("text-x-generic") : icon;
 }
 
+QMimeType mimeTypeForFile(const QString &path)
+{
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    if (path.startsWith(mountsDir)) {
+        return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchExtension);
+    }
+    return mimeDb().mimeTypeForFile(path, QMimeDatabase::MatchDefault);
+}
+
+QMimeType mimeTypeForFile(const QFileInfo &info)
+{
+    return mimeTypeForFile(info.absoluteFilePath());
+}
+
 // Resolve an icon for a file from its name (and optional precomputed
 // content type, e.g. from `gio list -a standard::content-type` for trash
 // entries). When no content type is given, ask QMimeDatabase based on the
@@ -304,7 +318,7 @@ QString iconNameForEntry(const QString &name, bool isDir, const QString &content
     // path is a real local file, MatchDefault will additionally sniff the
     // content when the glob is ambiguous, which is what disambiguates
     // .ts files between TypeScript and MPEG-TS video.
-    const QMimeType mime = mimeDb().mimeTypeForFile(name);
+    const QMimeType mime = mimeTypeForFile(name);
     return iconNameForMimeName(mime.name());
 }
 
@@ -320,7 +334,7 @@ QString fileTypeForEntry(const QString &name, bool isDir, const QString &content
         return contentType;
     }
 
-    const QMimeType mime = mimeDb().mimeTypeForFile(name);
+    const QMimeType mime = mimeTypeForFile(name);
     return mime.isValid() ? mime.comment() : QFileInfo(name).suffix();
 }
 
@@ -338,7 +352,7 @@ PreviewKind previewKindForEntry(const QString &localPath, bool isDir,
 
     QString mimeName = contentType;
     if (mimeName.isEmpty()) {
-        const QMimeType mime = mimeDb().mimeTypeForFile(localPath);
+        const QMimeType mime = mimeTypeForFile(localPath);
         if (mime.isValid())
             mimeName = mime.name();
     }
@@ -501,7 +515,7 @@ QVariantMap buildTrashEntryFromLocal(const XdgTrash::Entry &source)
 
     const QString contentType = isDir
         ? QStringLiteral("inode/directory")
-        : mimeDb().mimeTypeForFile(info).name();
+        : mimeTypeForFile(info).name();
     const QString mimeDescription = contentType.isEmpty()
         ? QString()
         : mimeDb().mimeTypeForName(contentType).comment();
@@ -751,7 +765,7 @@ QVariant FileSystemModel::data(const QModelIndex &index, int role) const
         return info.isDir() ? QString() : info.suffix();
     case MimeTypeRole:
         if (entry.mimeType.isEmpty())
-            entry.mimeType = mimeDb().mimeTypeForFile(info).name();
+            entry.mimeType = mimeTypeForFile(info).name();
         return entry.mimeType;
     case SymlinkTargetRole:
         return info.isSymLink() ? info.symLinkTarget() : QString();
@@ -821,6 +835,16 @@ QString FileSystemModel::rootPath() const { return m_rootPath; }
 bool FileSystemModel::showHidden() const { return m_showHidden; }
 int FileSystemModel::fileCount() const { return m_fileCount; }
 int FileSystemModel::folderCount() const { return m_folderCount; }
+
+bool FileSystemModel::isLoading() const { return m_isLoading; }
+
+void FileSystemModel::setIsLoading(bool loading)
+{
+    if (m_isLoading == loading)
+        return;
+    m_isLoading = loading;
+    emit isLoadingChanged();
+}
 
 bool FileSystemModel::isTrashRoot() const
 {
@@ -978,6 +1002,7 @@ QString FileSystemModel::fileName(int row) const
 
 void FileSystemModel::reload()
 {
+    setIsLoading(true);
     cancelRemoteReload();
     ++m_remoteReloadGeneration;
 
@@ -992,6 +1017,7 @@ void FileSystemModel::reload()
         reloadTrash();
         endResetModel();
         emit countsChanged();
+        setIsLoading(false);
         return;
     }
 
@@ -1079,6 +1105,7 @@ FileSystemModel::LocalReloadResult FileSystemModel::scanLocalEntries(
 
 void FileSystemModel::scheduleLocalReload(bool tryDiff)
 {
+    setIsLoading(true);
     const quint64 gen = ++m_localReloadGeneration;
     m_localReloadTryDiff = tryDiff;
 
@@ -1110,6 +1137,7 @@ void FileSystemModel::cancelLocalReload()
         return;
     m_localReloadWatcher->disconnect(this);
     m_localReloadWatcher->waitForFinished();
+    setIsLoading(false);
 }
 
 void FileSystemModel::applyLocalReload(LocalReloadResult result, bool tryDiff)
@@ -1120,8 +1148,10 @@ void FileSystemModel::applyLocalReload(LocalReloadResult result, bool tryDiff)
     if (result.generation != m_localReloadGeneration)
         return;
 
-    if (tryDiff && applyLocalDiff(result.entries))
+    if (tryDiff && applyLocalDiff(result.entries)) {
+        setIsLoading(false);
         return;
+    }
 
     beginResetModel();
     m_entries = std::move(result.entries);
@@ -1129,6 +1159,7 @@ void FileSystemModel::applyLocalReload(LocalReloadResult result, bool tryDiff)
     updateLocalCounts();
     endResetModel();
     emit countsChanged();
+    setIsLoading(false);
 }
 
 void FileSystemModel::reloadRemote()
@@ -1138,6 +1169,8 @@ void FileSystemModel::reloadRemote()
         m_folderCount = 0;
         return;
     }
+
+    setIsLoading(true);
 
     QStringList args = {
         QStringLiteral("list"),
@@ -1166,8 +1199,10 @@ void FileSystemModel::reloadRemote()
         m_remoteReloadProcess = nullptr;
         process->deleteLater();
 
-        if (output.isEmpty() && exitCode != 0)
+        if (output.isEmpty() && exitCode != 0) {
+            setIsLoading(false);
             return;
+        }
 
         applyRemoteReload(rootPath, output);
     });
@@ -1194,6 +1229,7 @@ void FileSystemModel::cancelRemoteReload()
     }
     m_remoteReloadProcess->deleteLater();
     m_remoteReloadProcess = nullptr;
+    setIsLoading(false);
 }
 
 void FileSystemModel::applyRemoteReload(const QString &rootPath, const QByteArray &output)
@@ -1280,6 +1316,7 @@ void FileSystemModel::applyRemoteReload(const QString &rootPath, const QByteArra
     m_folderCount = folders;
     endResetModel();
     emit countsChanged();
+    setIsLoading(false);
 }
 
 QList<FileSystemModel::Entry> FileSystemModel::currentLocalEntries() const
@@ -1314,14 +1351,27 @@ void FileSystemModel::ensurePopulated(const Entry &entry) const
     const bool isDir = entry.info.isDir();
     const QString absPath = entry.info.absoluteFilePath();
     entry.iconName = iconNameForEntry(absPath, isDir);
-    entry.fileType = fileTypeForEntry(entry.info.fileName(), isDir);
+    entry.fileType = fileTypeForEntry(absPath, isDir);
     entry.sizeText = isDir ? QString() : formattedSize(entry.info.size());
     entry.modifiedText = QLocale().toString(entry.info.lastModified(), QLocale::ShortFormat);
-    entry.permissionsText = permissionsString(entry.info);
-    entry.owner = entry.info.owner();
-    entry.group = entry.info.group();
-    entry.createdText = QLocale().toString(entry.info.birthTime(), QLocale::ShortFormat);
-    entry.accessedText = QLocale().toString(entry.info.lastRead(), QLocale::ShortFormat);
+
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    const bool isRemote = absPath.startsWith(mountsDir);
+
+    if (isRemote) {
+        entry.permissionsText = isDir ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
+        entry.owner = QStringLiteral("cloud");
+        entry.group = QStringLiteral("cloud");
+        entry.createdText = QString();
+        entry.accessedText = QString();
+    } else {
+        entry.permissionsText = permissionsString(entry.info);
+        entry.owner = entry.info.owner();
+        entry.group = entry.info.group();
+        entry.createdText = QLocale().toString(entry.info.birthTime(), QLocale::ShortFormat);
+        entry.accessedText = QLocale().toString(entry.info.lastRead(), QLocale::ShortFormat);
+    }
+
     const PreviewKind kind = previewKindForEntry(absPath, isDir);
     entry.hasImagePreview = kind == PreviewKind::Image;
     entry.hasVideoPreview = kind == PreviewKind::Video;
@@ -1512,6 +1562,7 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
     // Trash rows carry a real path under <trash>/files rather than a trash://
     // URI, so match against the loaded entries too — otherwise a trashed item
     // falls through to the plain-file branch and loses originalPath/deletedAt.
+
     if (isTrashUri(normalizedPath))
         return trashFileProperties(normalizedPath);
     if (isTrashRoot()) {
@@ -1521,6 +1572,9 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
 
     if (isRemoteUri(normalizedPath))
         return remoteFileProperties(normalizedPath);
+
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    const bool isRemote = normalizedPath.startsWith(mountsDir);
 
     QFileInfo info(normalizedPath);
     QVariantMap props;
@@ -1532,25 +1586,34 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
     props["isSymlink"] = info.isSymLink();
 
     // Icon name (reuse the same mapping as data())
-    props["iconName"] = iconNameForEntry(info.fileName(), info.isDir());
+    props["iconName"] = iconNameForEntry(info.absoluteFilePath(), info.isDir());
     if (info.isSymLink())
         props["symlinkTarget"] = info.symLinkTarget();
 
     // Size
     if (info.isDir()) {
-        QDir dir(normalizedPath);
-        auto allEntries = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden);
-        int fileCount = 0, folderCount = 0;
-        for (const auto &e : allEntries) {
-            if (e.isDir()) ++folderCount;
-            else ++fileCount;
+        if (isRemote) {
+            props["containedItems"] = QVariant();
+            props["containedFiles"] = QVariant();
+            props["containedFolders"] = QVariant();
+            props["contentText"] = QStringLiteral("Folder");
+            props["sizeText"] = QStringLiteral("Folder");
+            props["size"] = QVariant(static_cast<qint64>(-1));
+        } else {
+            QDir dir(normalizedPath);
+            auto allEntries = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden);
+            int fileCount = 0, folderCount = 0;
+            for (const auto &e : allEntries) {
+                if (e.isDir()) ++folderCount;
+                else ++fileCount;
+            }
+            props["containedItems"] = allEntries.count();
+            props["containedFiles"] = fileCount;
+            props["containedFolders"] = folderCount;
+            props["contentText"] = QString("%1 items (%2 files, %3 folders)").arg(allEntries.count()).arg(fileCount).arg(folderCount);
+            props["sizeText"] = QString("%1 items").arg(allEntries.count());
+            props["size"] = QVariant(static_cast<qint64>(-1));
         }
-        props["containedItems"] = allEntries.count();
-        props["containedFiles"] = fileCount;
-        props["containedFolders"] = folderCount;
-        props["contentText"] = QString("%1 items (%2 files, %3 folders)").arg(allEntries.count()).arg(fileCount).arg(folderCount);
-        props["sizeText"] = QString("%1 items").arg(allEntries.count());
-        props["size"] = QVariant(static_cast<qint64>(-1));
     } else {
         qint64 size = info.size();
         props["size"] = size;
@@ -1558,68 +1621,86 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
     }
 
     // Disk usage
-    QStorageInfo storage(info.absoluteFilePath());
-    if (storage.isValid()) {
-        qint64 total = storage.bytesTotal();
-        qint64 free = storage.bytesAvailable();
-        qint64 used = total - free;
-        double usedPct = total > 0 ? (double)used / total : 0;
-        double freePct = total > 0 ? (double)free / total : 0;
+    if (!isRemote) {
+        QStorageInfo storage(info.absoluteFilePath());
+        if (storage.isValid()) {
+            qint64 total = storage.bytesTotal();
+            qint64 free = storage.bytesAvailable();
+            qint64 used = total - free;
+            double usedPct = total > 0 ? (double)used / total : 0;
+            double freePct = total > 0 ? (double)free / total : 0;
 
-        auto fmtSize = [](qint64 s) -> QString {
-            if (s < 1024) return QString("%1 B").arg(s);
-            if (s < 1024LL * 1024) return QString("%1 KB").arg(s / 1024.0, 0, 'f', 1);
-            if (s < 1024LL * 1024 * 1024) return QString("%1 MB").arg(s / (1024.0 * 1024.0), 0, 'f', 1);
-            return QString("%1 GB").arg(s / (1024.0 * 1024.0 * 1024.0), 0, 'f', 1);
-        };
-        props["diskTotal"] = fmtSize(total);
-        props["diskUsed"] = fmtSize(used);
-        props["diskFree"] = fmtSize(free);
-        props["diskUsedPercent"] = usedPct;
-        props["diskUsedPctText"] = QString("%1%").arg(qRound(usedPct * 100));
-        props["diskFreePctText"] = QString("%1%").arg(qRound(freePct * 100));
+            auto fmtSize = [](qint64 s) -> QString {
+                if (s < 1024) return QString("%1 B").arg(s);
+                if (s < 1024LL * 1024) return QString("%1 KB").arg(s / 1024.0, 0, 'f', 1);
+                if (s < 1024LL * 1024 * 1024) return QString("%1 MB").arg(s / (1024.0 * 1024.0), 0, 'f', 1);
+                return QString("%1 GB").arg(s / (1024.0 * 1024.0 * 1024.0), 0, 'f', 1);
+            };
+            props["diskTotal"] = fmtSize(total);
+            props["diskUsed"] = fmtSize(used);
+            props["diskFree"] = fmtSize(free);
+            props["diskUsedPercent"] = usedPct;
+            props["diskUsedPctText"] = QString("%1%").arg(qRound(usedPct * 100));
+            props["diskFreePctText"] = QString("%1%").arg(qRound(freePct * 100));
+        }
     }
 
     // MIME type
-    auto mime = mimeDb().mimeTypeForFile(info);
+    auto mime = mimeTypeForFile(info);
     props["mimeType"] = mime.name();
     props["mimeDescription"] = mime.comment();
 
-    // Timestamps
-    props["created"] = QLocale().toString(info.birthTime(), QLocale::LongFormat);
-    props["modified"] = QLocale().toString(info.lastModified(), QLocale::LongFormat);
-    props["accessed"] = QLocale().toString(info.lastRead(), QLocale::LongFormat);
+    if (isRemote) {
+        props["created"] = QString();
+        props["modified"] = QLocale().toString(info.lastModified(), QLocale::LongFormat);
+        props["accessed"] = QString();
 
-    // Ownership
-    props["owner"] = info.owner();
-    props["group"] = info.group();
+        props["owner"] = QStringLiteral("cloud");
+        props["group"] = QStringLiteral("cloud");
 
-    // Permissions string
-    auto p = info.permissions();
-    QString permStr;
-    permStr += (p & QFile::ReadOwner)  ? 'r' : '-';
-    permStr += (p & QFile::WriteOwner) ? 'w' : '-';
-    permStr += (p & QFile::ExeOwner)   ? 'x' : '-';
-    permStr += (p & QFile::ReadGroup)  ? 'r' : '-';
-    permStr += (p & QFile::WriteGroup) ? 'w' : '-';
-    permStr += (p & QFile::ExeGroup)   ? 'x' : '-';
-    permStr += (p & QFile::ReadOther)  ? 'r' : '-';
-    permStr += (p & QFile::WriteOther) ? 'w' : '-';
-    permStr += (p & QFile::ExeOther)   ? 'x' : '-';
-    props["permissions"] = permStr;
+        props["permissions"] = info.isDir() ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
 
-    // Per-role access index: 0=None, 1=Read only, 2=Read & Write, 3=Read & Write & Execute
-    // (for dropdown selectors)
-    auto accessIndex = [](bool r, bool w, bool x) -> int {
-        if (r && w && x) return 3;
-        if (r && w)      return 2;
-        if (r)           return 1;
-        return 0;
-    };
-    props["ownerAccess"] = accessIndex(p & QFile::ReadOwner, p & QFile::WriteOwner, p & QFile::ExeOwner);
-    props["groupAccess"] = accessIndex(p & QFile::ReadGroup, p & QFile::WriteGroup, p & QFile::ExeGroup);
-    props["otherAccess"] = accessIndex(p & QFile::ReadOther, p & QFile::WriteOther, p & QFile::ExeOther);
-    props["isExecutable"] = bool(p & QFile::ExeOwner);
+        props["ownerAccess"] = 2;
+        props["groupAccess"] = 1;
+        props["otherAccess"] = 1;
+        props["isExecutable"] = false;
+    } else {
+        // Timestamps
+        props["created"] = QLocale().toString(info.birthTime(), QLocale::LongFormat);
+        props["modified"] = QLocale().toString(info.lastModified(), QLocale::LongFormat);
+        props["accessed"] = QLocale().toString(info.lastRead(), QLocale::LongFormat);
+
+        // Ownership
+        props["owner"] = info.owner();
+        props["group"] = info.group();
+
+        // Permissions string
+        auto p = info.permissions();
+        QString permStr;
+        permStr += (p & QFile::ReadOwner)  ? 'r' : '-';
+        permStr += (p & QFile::WriteOwner) ? 'w' : '-';
+        permStr += (p & QFile::ExeOwner)   ? 'x' : '-';
+        permStr += (p & QFile::ReadGroup)  ? 'r' : '-';
+        permStr += (p & QFile::WriteGroup) ? 'w' : '-';
+        permStr += (p & QFile::ExeGroup)   ? 'x' : '-';
+        permStr += (p & QFile::ReadOther)  ? 'r' : '-';
+        permStr += (p & QFile::WriteOther) ? 'w' : '-';
+        permStr += (p & QFile::ExeOther)   ? 'x' : '-';
+        props["permissions"] = permStr;
+
+        // Per-role access index: 0=None, 1=Read only, 2=Read & Write, 3=Read & Write & Execute
+        // (for dropdown selectors)
+        auto accessIndex = [](bool r, bool w, bool x) -> int {
+            if (r && w && x) return 3;
+            if (r && w)      return 2;
+            if (r)           return 1;
+            return 0;
+        };
+        props["ownerAccess"] = accessIndex(p & QFile::ReadOwner, p & QFile::WriteOwner, p & QFile::ExeOwner);
+        props["groupAccess"] = accessIndex(p & QFile::ReadGroup, p & QFile::WriteGroup, p & QFile::ExeGroup);
+        props["otherAccess"] = accessIndex(p & QFile::ReadOther, p & QFile::WriteOther, p & QFile::ExeOther);
+        props["isExecutable"] = bool(p & QFile::ExeOwner);
+    }
 
     return props;
 }

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -1359,9 +1359,12 @@ void FileSystemModel::ensurePopulated(const Entry &entry) const
     const bool isRemote = isCloudMountPath(absPath);
 
     if (isRemote) {
-        entry.permissionsText = isDir ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
-        entry.owner = QStringLiteral("cloud");
-        entry.group = QStringLiteral("cloud");
+        // A FUSE mount reports the mounting user for every entry and stats
+        // cost a round trip, so none of this is worth fetching. Leave it
+        // blank the way trash entries do rather than invent plausible values.
+        entry.permissionsText = QString();
+        entry.owner = QString();
+        entry.group = QString();
         entry.createdText = QString();
         entry.accessedText = QString();
     } else {
@@ -1654,14 +1657,12 @@ QVariantMap FileSystemModel::fileProperties(const QString &path) const
         props["modified"] = QLocale().toString(info.lastModified(), QLocale::LongFormat);
         props["accessed"] = QString();
 
-        props["owner"] = QStringLiteral("cloud");
-        props["group"] = QStringLiteral("cloud");
-
-        props["permissions"] = info.isDir() ? QStringLiteral("drwxr-xr-x") : QStringLiteral("-rw-r--r--");
-
-        props["ownerAccess"] = 2;
-        props["groupAccess"] = 1;
-        props["otherAccess"] = 1;
+        props["owner"] = QString();
+        props["group"] = QString();
+        props["permissions"] = QString();
+        props["ownerAccess"] = 0;
+        props["groupAccess"] = 0;
+        props["otherAccess"] = 0;
         props["isExecutable"] = false;
         props["canEditPermissions"] = false;
     } else {

--- a/src/models/filesystemmodel.h
+++ b/src/models/filesystemmodel.h
@@ -27,6 +27,7 @@ class FileSystemModel : public QAbstractListModel
     // listing and the disk figures are refreshed by the same events.
     Q_PROPERTY(qint64 diskFree READ diskFree NOTIFY countsChanged)
     Q_PROPERTY(qint64 diskTotal READ diskTotal NOTIFY countsChanged)
+    Q_PROPERTY(bool isLoading READ isLoading NOTIFY isLoadingChanged)
 
 public:
     enum Roles {
@@ -71,6 +72,7 @@ public:
     bool showHidden() const;
     int fileCount() const;
     int folderCount() const;
+    bool isLoading() const;
 
     Q_INVOKABLE void setRootPath(const QString &path);
     Q_INVOKABLE void setShowHidden(bool show);
@@ -105,6 +107,7 @@ signals:
     void rootPathChanged();
     void showHiddenChanged();
     void countsChanged();
+    void isLoadingChanged();
     void watchedDirectoryChanged(const QString &path);
 
 private:
@@ -164,6 +167,7 @@ private:
     QVariantMap remoteFileProperties(const QString &path) const;
     QVariantMap trashFileProperties(const QString &path) const;
     const QVariantMap *findTrashEntry(const QString &path) const;
+    void setIsLoading(bool loading);
 
     // QStorageInfo for rootPath, or an invalid one where reporting a disk
     // would mislead.
@@ -188,4 +192,5 @@ private:
     QDir::SortFlags m_sortFlags = QDir::Name | QDir::DirsFirst | QDir::IgnoreCase;
     QString m_sortColumn = "name";
     bool m_sortAscending = true;
+    bool m_isLoading = false;
 };

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -548,9 +548,11 @@ ApplicationWindow {
         if (rcloneService.isRclonePath(path)) {
             var remote = rcloneService.getRemoteNameFromPath(path)
             if (!rcloneService.isMounted(remote)) {
-                toast.show("Mounting cloud storage '" + remote + "'...", "info")
                 pendingCloudCallbacks.push({ remote: remote, callback: callback })
-                rcloneService.mountRemote(remote)
+                if (!rcloneService.isMounting(remote)) {
+                    toast.show("Mounting cloud storage '" + remote + "'...", "info")
+                    rcloneService.mountRemote(remote)
+                }
                 return
             }
         }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -33,6 +33,7 @@ ApplicationWindow {
         ? secondaryPaneIsRecents
         : primaryPaneIsRecents
     property var deleteConfirmPaths: []
+    property var pendingCloudCallbacks: []
     property var transferConflictItems: []
     property var transferResolvedItems: []
     property int transferConflictIndex: -1
@@ -543,17 +544,32 @@ ApplicationWindow {
         root.setActivePane(activePane === "primary" ? "secondary" : "primary")
     }
 
+    function ensureMountedAndRun(path, callback) {
+        if (rcloneService.isRclonePath(path)) {
+            var remote = rcloneService.getRemoteNameFromPath(path)
+            if (!rcloneService.isMounted(remote)) {
+                toast.show("Mounting cloud storage '" + remote + "'...", "info")
+                pendingCloudCallbacks.push({ remote: remote, callback: callback })
+                rcloneService.mountRemote(remote)
+                return
+            }
+        }
+        callback()
+    }
+
     function navigatePaneTo(pane, path) {
         if (!tabModel.activeTab || !path)
             return
 
-        root.setPaneRecents(pane, false)
-        root.clearPaneSearch(pane)
-        if (pane === "secondary" && splitViewEnabled())
-            tabModel.activeTab.navigateSecondaryTo(path)
-        else
-            tabModel.activeTab.navigateTo(path)
-        root.scheduleActivePaneFocus()
+        ensureMountedAndRun(path, function() {
+            root.setPaneRecents(pane, false)
+            root.clearPaneSearch(pane)
+            if (pane === "secondary" && splitViewEnabled())
+                tabModel.activeTab.navigateSecondaryTo(path)
+            else
+                tabModel.activeTab.navigateTo(path)
+            root.scheduleActivePaneFocus()
+        })
     }
 
     function navigateActivePaneTo(path) {
@@ -564,11 +580,13 @@ ApplicationWindow {
         if (!path)
             return
 
-        root.setPaneRecents(root.activePane, false)
-        tabModel.addTab()
-        if (tabModel.activeTab)
-            tabModel.activeTab.navigateTo(path)
-        root.scheduleActivePaneFocus()
+        ensureMountedAndRun(path, function() {
+            root.setPaneRecents(root.activePane, false)
+            tabModel.addTab()
+            if (tabModel.activeTab)
+                tabModel.activeTab.navigateTo(path)
+            root.scheduleActivePaneFocus()
+        })
     }
 
     function resetTransferConflictState() {
@@ -3779,6 +3797,7 @@ ApplicationWindow {
                     selectedSizePending: root.currentSelectedSizePending
                     diskFree: root.activeDiskFree()
                     diskTotal: root.activeDiskTotal()
+                    isLoading: (activePane === "secondary" ? splitFsModel : fsModel).isLoading
                 }
             }
         }
@@ -3872,6 +3891,27 @@ ApplicationWindow {
         target: splitFsModel
         function onWatchedDirectoryChanged(path) {
             diskUsageService.invalidatePath(path)
+        }
+    }
+
+    Connections {
+        target: rcloneService
+        function onMountFinished(remoteName, success, error) {
+            var remaining = []
+            for (var i = 0; i < pendingCloudCallbacks.length; ++i) {
+                var item = pendingCloudCallbacks[i]
+                if (item.remote === remoteName) {
+                    if (success) {
+                        toast.show("Cloud storage mounted successfully", "success")
+                        item.callback()
+                    } else {
+                        toast.show("Failed to mount cloud: " + error, "error")
+                    }
+                } else {
+                    remaining.push(item)
+                }
+            }
+            pendingCloudCallbacks = remaining
         }
     }
 }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -2017,7 +2017,7 @@ ApplicationWindow {
                 apps = []
 
             // Extract rich metadata
-            var md = fileOps.isRemotePath(path) ? ({}) : metadataExtractor.extract(path)
+            var md = (fileOps.isRemotePath(path) || fileOps.isSlowPath(path)) ? ({}) : metadataExtractor.extract(path)
             var keys = Object.keys(md)
             var result = []
             for (var i = 0; i < keys.length; ++i) {
@@ -2025,7 +2025,7 @@ ApplicationWindow {
                     result.push({ label: keys[i], value: String(md[keys[i]]) })
             }
             _metadataKeys = result
-            _metadataHint = fileOps.isRemotePath(path) ? "" : metadataExtractor.missingDepsHint(props.mimeType || "")
+            _metadataHint = (fileOps.isRemotePath(path) || fileOps.isSlowPath(path)) ? "" : metadataExtractor.missingDepsHint(props.mimeType || "")
 
             visible = true
             propsBox.opacity = 0

--- a/src/qml/components/StatusBar.qml
+++ b/src/qml/components/StatusBar.qml
@@ -30,6 +30,7 @@ Rectangle {
     // recents). Real numbers, not int: a disk is bigger than 2 GiB.
     property real diskFree: -1
     property real diskTotal: -1
+    property bool isLoading: false
 
     height: 28
     color: Theme.mantle
@@ -74,8 +75,47 @@ Rectangle {
         anchors.leftMargin: Theme.spacing
         anchors.rightMargin: Theme.spacing
 
+        RowLayout {
+            Layout.fillWidth: true
+            visible: statusBar.isLoading
+            spacing: 6
+
+            Rectangle {
+                width: 12
+                height: 12
+                radius: 6
+                color: "transparent"
+                border.color: Qt.rgba(Theme.text.r, Theme.text.g, Theme.text.b, 0.15)
+                border.width: 2
+
+                Rectangle {
+                    width: 4
+                    height: 4
+                    x: 4; y: 0
+                    radius: 2
+                    color: Theme.accent
+                }
+
+                RotationAnimator on rotation {
+                    from: 0
+                    to: 360
+                    duration: 1000
+                    loops: Animation.Infinite
+                    running: statusBar.isLoading
+                }
+            }
+
+            Text {
+                text: "Loading directory..."
+                color: Theme.accent
+                font.pointSize: Theme.fontSmall
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+
         Text {
             Layout.fillWidth: true
+            visible: !statusBar.isLoading
             text: {
                 const files = statusBar.itemCount - statusBar.folderCount
                 return statusBar.itemCount + " items (" + statusBar.folderCount + " folders, " + files + " files)"

--- a/src/qml/components/StatusBar.qml
+++ b/src/qml/components/StatusBar.qml
@@ -32,6 +32,26 @@ Rectangle {
     property real diskTotal: -1
     property bool isLoading: false
 
+    // A local directory lists in a few milliseconds, so showing the spinner the
+    // moment a load starts only flashes the item count off and straight back on
+    // every navigation. Wait until a load is slow enough to be worth reporting.
+    property bool showLoading: false
+
+    Timer {
+        id: loadingDelay
+        interval: 300
+        onTriggered: statusBar.showLoading = true
+    }
+
+    onIsLoadingChanged: {
+        if (statusBar.isLoading) {
+            loadingDelay.restart()
+        } else {
+            loadingDelay.stop()
+            statusBar.showLoading = false
+        }
+    }
+
     height: 28
     color: Theme.mantle
     clip: false
@@ -77,7 +97,7 @@ Rectangle {
 
         RowLayout {
             Layout.fillWidth: true
-            visible: statusBar.isLoading
+            visible: statusBar.showLoading
             spacing: 6
 
             Rectangle {
@@ -101,7 +121,7 @@ Rectangle {
                     to: 360
                     duration: 1000
                     loops: Animation.Infinite
-                    running: statusBar.isLoading
+                    running: statusBar.showLoading
                 }
             }
 
@@ -115,7 +135,7 @@ Rectangle {
 
         Text {
             Layout.fillWidth: true
-            visible: !statusBar.isLoading
+            visible: !statusBar.showLoading
             text: {
                 const files = statusBar.itemCount - statusBar.folderCount
                 return statusBar.itemCount + " items (" + statusBar.folderCount + " folders, " + files + " files)"

--- a/src/qml/views/FileDetailedView.qml
+++ b/src/qml/views/FileDetailedView.qml
@@ -63,7 +63,7 @@ FocusScope {
         for (var i = first; i <= last; ++i) {
             if (isDirForRow(i)) {
                 var p = pathForRow(i)
-                if (p && !fileOps.isRemotePath(p))
+                if (p && !fileOps.isRemotePath(p) && !fileOps.isSlowPath(p))
                     paths.push(p)
             }
         }
@@ -1017,7 +1017,7 @@ FocusScope {
                             height: root.detailIconSize
                             anchors.verticalCenter: parent.verticalCenter
 
-                            readonly property bool hasThumbnail: !fileOps.isRemotePath(detRow.filePath)
+                            readonly property bool hasThumbnail: !fileOps.isRemotePath(detRow.filePath) && !fileOps.isSlowPath(detRow.filePath)
                                 && (detRow.hasImagePreview || detRow.hasVideoPreview
                                     || detRow.hasPdfPreview)
 

--- a/src/qml/views/FileGridView.qml
+++ b/src/qml/views/FileGridView.qml
@@ -575,7 +575,7 @@ GridView {
             }
         }
 
-        readonly property bool hasThumbnail: !fileOps.isRemotePath(delegateItem.filePath)
+        readonly property bool hasThumbnail: !fileOps.isRemotePath(delegateItem.filePath) && !fileOps.isSlowPath(delegateItem.filePath)
             && (delegateItem.hasImagePreview || delegateItem.hasVideoPreview
                 || delegateItem.hasPdfPreview)
 

--- a/src/qml/views/FileMillerView.qml
+++ b/src/qml/views/FileMillerView.qml
@@ -885,7 +885,7 @@ FocusScope {
                             width: root.millerIconSize + 2; height: root.millerIconSize + 2
                             anchors.verticalCenter: parent.verticalCenter
 
-                            readonly property bool hasThumbnail: !fileOps.isRemotePath(currentDelegate.filePath)
+                            readonly property bool hasThumbnail: !fileOps.isRemotePath(currentDelegate.filePath) && !fileOps.isSlowPath(currentDelegate.filePath)
                                 && (currentDelegate.hasImagePreview || currentDelegate.hasVideoPreview)
 
                             Image {

--- a/src/services/cloudmounts.h
+++ b/src/services/cloudmounts.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QDir>
+#include <QString>
+
+// Where the rclone mounts live. Five call sites across the model, the git
+// service and the file operations need to recognise these paths, so the
+// directory is defined once here rather than spelled out in each of them.
+inline QString cloudMountsBaseDir()
+{
+    static const QString dir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    return dir;
+}
+
+// True for a path inside a mount, not for the mounts directory itself: the
+// container is an ordinary local folder and must stay browsable.
+inline bool isCloudMountPath(const QString &path)
+{
+    static const QString prefix = cloudMountsBaseDir() + QLatin1Char('/');
+    return path.startsWith(prefix) && path.length() > prefix.length();
+}

--- a/src/services/dependencychecker.cpp
+++ b/src/services/dependencychecker.cpp
@@ -445,6 +445,15 @@ void DependencyChecker::populate()
         Kind::Feature, false, hasKWin, {},
         buildFeatureHint(QStringLiteral("kwindowsystem"))
     });
+
+    m_deps.append({
+        QStringLiteral("rclone"),
+        QStringLiteral("rclone"),
+        QStringLiteral("Mount cloud storage services (Google Drive, OneDrive, etc.)."),
+        Kind::Tool, false, hasExecutable(QStringLiteral("rclone")),
+        {QStringLiteral("rclone")},
+        buildHints(QStringLiteral("rclone"))
+    });
 }
 
 QVariantList DependencyChecker::dependencies() const

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -93,6 +93,10 @@ bool isUriPath(const QString &path)
 
 bool isRemoteUriPath(const QString &path)
 {
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    if (path.startsWith(mountsDir))
+        return true;
+
     const QUrl url(path);
     return url.isValid() && !url.scheme().isEmpty()
         && url.scheme() != QStringLiteral("file")

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -1596,9 +1596,9 @@ bool FileOperations::pathExists(const QString &path) const
 
 bool FileOperations::isRemotePath(const QString &path) const
 {
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
     const QString normalized = normalizeLocation(path);
-    if (normalized.startsWith(mountsDir))
+    if (normalized.startsWith(prefix))
         return true;
     return isRemoteUriPath(normalized);
 }

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -1596,11 +1596,13 @@ bool FileOperations::pathExists(const QString &path) const
 
 bool FileOperations::isRemotePath(const QString &path) const
 {
+    return isRemoteUriPath(normalizeLocation(path));
+}
+
+bool FileOperations::isSlowPath(const QString &path) const
+{
     static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
-    const QString normalized = normalizeLocation(path);
-    if (normalized.startsWith(prefix))
-        return true;
-    return isRemoteUriPath(normalized);
+    return normalizeLocation(path).startsWith(prefix);
 }
 
 QString FileOperations::parentPath(const QString &path) const

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -93,10 +93,6 @@ bool isUriPath(const QString &path)
 
 bool isRemoteUriPath(const QString &path)
 {
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
-    if (path.startsWith(mountsDir))
-        return true;
-
     const QUrl url(path);
     return url.isValid() && !url.scheme().isEmpty()
         && url.scheme() != QStringLiteral("file")
@@ -1600,7 +1596,11 @@ bool FileOperations::pathExists(const QString &path) const
 
 bool FileOperations::isRemotePath(const QString &path) const
 {
-    return isRemoteUriPath(normalizeLocation(path));
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    const QString normalized = normalizeLocation(path);
+    if (normalized.startsWith(mountsDir))
+        return true;
+    return isRemoteUriPath(normalized);
 }
 
 QString FileOperations::parentPath(const QString &path) const

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -1,5 +1,6 @@
 #include "services/fileoperations.h"
 #include "services/archivepassword.h"
+#include "services/cloudmounts.h"
 #include "services/giotransferworker.h"
 #include "services/xdgtrash.h"
 #include <QBuffer>
@@ -1709,8 +1710,7 @@ bool FileOperations::isRemotePath(const QString &path) const
 
 bool FileOperations::isSlowPath(const QString &path) const
 {
-    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
-    return normalizeLocation(path).startsWith(prefix);
+    return isCloudMountPath(normalizeLocation(path));
 }
 
 QString FileOperations::parentPath(const QString &path) const

--- a/src/services/fileoperations.h
+++ b/src/services/fileoperations.h
@@ -62,6 +62,7 @@ public:
     Q_INVOKABLE void openInEditor(const QString &path);
     Q_INVOKABLE bool pathExists(const QString &path) const;
     Q_INVOKABLE bool isRemotePath(const QString &path) const;
+    Q_INVOKABLE bool isSlowPath(const QString &path) const;
     Q_INVOKABLE QString parentPath(const QString &path) const;
     Q_INVOKABLE QString displayNameForPath(const QString &path) const;
     Q_INVOKABLE QVariantList breadcrumbSegments(const QString &path) const;

--- a/src/services/gitstatusservice.cpp
+++ b/src/services/gitstatusservice.cpp
@@ -330,8 +330,10 @@ void GitStatusService::markParentsDirty(const QString &filePath)
 
 bool GitStatusService::isRemotePath(const QString &path) const
 {
+    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
     return path.startsWith(QStringLiteral("smb://")) ||
            path.startsWith(QStringLiteral("sftp://")) ||
            path.startsWith(QStringLiteral("ftp://")) ||
-           path.startsWith(QStringLiteral("trash://"));
+           path.startsWith(QStringLiteral("trash://")) ||
+           path.startsWith(mountsDir);
 }

--- a/src/services/gitstatusservice.cpp
+++ b/src/services/gitstatusservice.cpp
@@ -1,4 +1,5 @@
 #include "services/gitstatusservice.h"
+#include "services/cloudmounts.h"
 
 #include <QDir>
 #include <QFile>
@@ -330,10 +331,9 @@ void GitStatusService::markParentsDirty(const QString &filePath)
 
 bool GitStatusService::isRemotePath(const QString &path) const
 {
-    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
     return path.startsWith(QStringLiteral("smb://")) ||
            path.startsWith(QStringLiteral("sftp://")) ||
            path.startsWith(QStringLiteral("ftp://")) ||
            path.startsWith(QStringLiteral("trash://")) ||
-           path.startsWith(prefix);
+           isCloudMountPath(path);
 }

--- a/src/services/gitstatusservice.cpp
+++ b/src/services/gitstatusservice.cpp
@@ -330,10 +330,10 @@ void GitStatusService::markParentsDirty(const QString &filePath)
 
 bool GitStatusService::isRemotePath(const QString &path) const
 {
-    static const QString mountsDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    static const QString prefix = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts/");
     return path.startsWith(QStringLiteral("smb://")) ||
            path.startsWith(QStringLiteral("sftp://")) ||
            path.startsWith(QStringLiteral("ftp://")) ||
            path.startsWith(QStringLiteral("trash://")) ||
-           path.startsWith(mountsDir);
+           path.startsWith(prefix);
 }

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -206,10 +206,6 @@ void RcloneService::startRcloneMountProcess(const QString &remoteName, const QSt
         QStringLiteral("writes"),
         QStringLiteral("--vfs-cache-max-age"),
         QStringLiteral("72h"),
-        QStringLiteral("--dir-cache-time"),
-        QStringLiteral("72h"),
-        QStringLiteral("--attr-timeout"),
-        QStringLiteral("72h"),
         QStringLiteral("--no-checksum"),
         QStringLiteral("--vfs-read-chunk-size"),
         QStringLiteral("1M"),
@@ -218,9 +214,7 @@ void RcloneService::startRcloneMountProcess(const QString &remoteName, const QSt
         QStringLiteral("--buffer-size"),
         QStringLiteral("32M"),
         QStringLiteral("--poll-interval"),
-        QStringLiteral("15s"),
-        QStringLiteral("-o"),
-        QStringLiteral("big_writes")
+        QStringLiteral("15s")
     });
 
     // Poll mountpoint checks every 100ms to verify FUSE mount is active

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -20,11 +20,22 @@ RcloneService::RcloneService(QObject *parent)
 
 RcloneService::~RcloneService()
 {
-    // Clean up all active mounts on app exit
+    // unmountRemote() drives fusermount through the event loop, and by the
+    // time we are destroyed there is no event loop left to run it: the
+    // unmount would never happen and ~QProcess would SIGKILL rclone with the
+    // FUSE mount still attached, leaving a dead mount point behind. Detach
+    // fusermount so it outlives us, then ask rclone to go away.
     const QStringList remotes = m_processes.keys();
     for (const QString &remote : remotes) {
-        unmountRemote(remote);
+        const QString mountPath = getMountPath(remote);
+        if (!QProcess::startDetached(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath}))
+            QProcess::startDetached(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
+
+        QProcess *proc = m_processes.value(remote);
+        if (proc && proc->state() != QProcess::NotRunning)
+            proc->terminate();
     }
+    m_processes.clear();
 }
 
 bool RcloneService::rcloneAvailable() const

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -1,5 +1,7 @@
 #include "services/rcloneservice.h"
 
+#include "services/cloudmounts.h"
+
 #include <QDir>
 #include <QStandardPaths>
 #include <QTimer>
@@ -16,7 +18,7 @@ RcloneService::RcloneService(QObject *parent)
     : QObject(parent)
 {
     m_rcloneAvailable = checkRcloneAvailable();
-    m_mountsBaseDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    m_mountsBaseDir = cloudMountsBaseDir();
     ensureMountsBaseDirExists();
 }
 
@@ -51,8 +53,7 @@ void RcloneService::ensureMountsBaseDirExists() const
 
 bool RcloneService::isRclonePath(const QString &path) const
 {
-    const QString prefix = m_mountsBaseDir + QStringLiteral("/");
-    return path.startsWith(prefix) && path.length() > prefix.length();
+    return isCloudMountPath(path);
 }
 
 bool RcloneService::isMounted(const QString &remoteName) const

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -3,6 +3,7 @@
 #include "services/cloudmounts.h"
 
 #include <QDir>
+#include <QPointer>
 #include <QStandardPaths>
 #include <QTimer>
 #include <QDebug>
@@ -167,6 +168,7 @@ void RcloneService::runUnmountTool(const QString &tool, const QString &mountPath
 void RcloneService::startRcloneMountProcess(const QString &remoteName, const QString &mountPath)
 {
     QProcess *proc = new QProcess(this);
+    const quint64 generation = ++m_mountGeneration[remoteName];
     m_processes.insert(remoteName, proc);
     m_mountSuccessEmitted[remoteName] = false;
     emit activeMountsChanged();
@@ -245,15 +247,24 @@ void RcloneService::startRcloneMountProcess(const QString &remoteName, const QSt
         }
     });
 
-    // Timeout safety: if it doesn't mount in 10 seconds, abort
-    QTimer::singleShot(10000, this, [this, remoteName, mountTimer]() {
-        if (m_processes.contains(remoteName) && !m_mountSuccessEmitted.value(remoteName)) {
-            mountTimer->stop();
-            mountTimer->deleteLater();
+    // Timeout safety: if it doesn't mount in 10 seconds, abort. The poll timer
+    // deletes itself as soon as the process is gone, so hold it weakly, and
+    // bail out when a newer attempt has taken over this remote -- otherwise a
+    // remount inside the timeout window would tear down the fresh mount.
+    QPointer<QTimer> pollTimer(mountTimer);
+    QTimer::singleShot(10000, this, [this, remoteName, generation, pollTimer]() {
+        if (m_mountGeneration.value(remoteName) != generation)
+            return;
+        if (!m_processes.contains(remoteName) || m_mountSuccessEmitted.value(remoteName))
+            return;
 
-            unmountRemote(remoteName);
-            emit mountFinished(remoteName, false, QStringLiteral("Mount operation timed out. Verify your rclone remote or network connection."));
+        if (pollTimer) {
+            pollTimer->stop();
+            pollTimer->deleteLater();
         }
+
+        unmountRemote(remoteName);
+        emit mountFinished(remoteName, false, QStringLiteral("Mount operation timed out. Verify your rclone remote or network connection."));
     });
 
     mountTimer->start(100);

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -1,0 +1,277 @@
+#include "services/rcloneservice.h"
+
+#include <QDir>
+#include <QStandardPaths>
+#include <QTimer>
+#include <QDebug>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace {
+    QHash<QString, bool> m_mountSuccessEmitted;
+}
+
+RcloneService::RcloneService(QObject *parent)
+    : QObject(parent)
+{
+    m_rcloneAvailable = checkRcloneAvailable();
+    m_mountsBaseDir = QDir::homePath() + QStringLiteral("/.local/share/hyprfm/mounts");
+    ensureMountsBaseDirExists();
+}
+
+RcloneService::~RcloneService()
+{
+    // Clean up all active mounts on app exit
+    const QStringList remotes = m_processes.keys();
+    for (const QString &remote : remotes) {
+        unmountRemote(remote);
+    }
+}
+
+bool RcloneService::rcloneAvailable() const
+{
+    return m_rcloneAvailable;
+}
+
+QStringList RcloneService::activeMounts() const
+{
+    return m_processes.keys();
+}
+
+bool RcloneService::checkRcloneAvailable() const
+{
+    return !QStandardPaths::findExecutable(QStringLiteral("rclone")).isEmpty();
+}
+
+void RcloneService::ensureMountsBaseDirExists() const
+{
+    QDir().mkpath(m_mountsBaseDir);
+}
+
+QStringList RcloneService::getRemotes()
+{
+    if (!m_rcloneAvailable)
+        return {};
+
+    QProcess proc;
+    proc.start(QStringLiteral("rclone"), {QStringLiteral("listremotes")});
+    if (proc.waitForFinished(3000)) {
+        QString out = QString::fromUtf8(proc.readAllStandardOutput());
+        QStringList list;
+        const QStringList lines = out.split(QLatin1Char('\n'));
+        for (const QString &line : lines) {
+            QString trimmed = line.trimmed();
+            if (trimmed.endsWith(QLatin1Char(':'))) {
+                trimmed.chop(1);
+            }
+            if (!trimmed.isEmpty()) {
+                list.append(trimmed);
+            }
+        }
+        return list;
+    }
+    return {};
+}
+
+bool RcloneService::isRclonePath(const QString &path) const
+{
+    if (!path.startsWith(m_mountsBaseDir))
+        return false;
+
+    if (path.length() <= m_mountsBaseDir.length())
+        return false;
+
+    QString sub = path.mid(m_mountsBaseDir.length());
+    if (sub.startsWith(QLatin1Char('/'))) {
+        sub = sub.mid(1);
+    }
+
+    return !sub.isEmpty();
+}
+
+bool RcloneService::isMounted(const QString &remoteName) const
+{
+    return m_processes.contains(remoteName);
+}
+
+bool RcloneService::isMountedForPath(const QString &path) const
+{
+    const QString remote = getRemoteNameFromPath(path);
+    if (remote.isEmpty())
+        return false;
+    return isMounted(remote);
+}
+
+QString RcloneService::getRemoteNameFromPath(const QString &path) const
+{
+    if (!isRclonePath(path))
+        return {};
+
+    QString sub = path.mid(m_mountsBaseDir.length());
+    if (sub.startsWith(QLatin1Char('/'))) {
+        sub = sub.mid(1);
+    }
+    int slashIdx = sub.indexOf(QLatin1Char('/'));
+    if (slashIdx != -1) {
+        return sub.left(slashIdx);
+    }
+    return sub;
+}
+
+QString RcloneService::getMountPath(const QString &remoteName) const
+{
+    return m_mountsBaseDir + QStringLiteral("/") + remoteName;
+}
+
+void RcloneService::mountRemote(const QString &remoteName)
+{
+    if (!m_rcloneAvailable) {
+        emit mountFinished(remoteName, false, QStringLiteral("rclone executable not found"));
+        return;
+    }
+
+    if (isMounted(remoteName)) {
+        emit mountFinished(remoteName, true, QString());
+        return;
+    }
+
+    const QString mountPath = getMountPath(remoteName);
+    QDir().mkpath(mountPath);
+
+    // Clean up any stale or lingering FUSE mounts from previous sessions/crashes
+    QProcess unmountProc;
+    unmountProc.start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
+    if (!unmountProc.waitForFinished(500) || unmountProc.exitCode() != 0) {
+        QProcess unmountProc3;
+        unmountProc3.start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
+        unmountProc3.waitForFinished(500);
+    }
+
+    QProcess *proc = new QProcess(this);
+    m_processes.insert(remoteName, proc);
+    m_mountSuccessEmitted[remoteName] = false;
+    emit activeMountsChanged();
+
+    connect(proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+            [this, remoteName, proc](int exitCode, QProcess::ExitStatus) {
+        const QString err = QString::fromUtf8(proc->readAllStandardError()).trimmed();
+        m_processes.remove(remoteName);
+        emit activeMountsChanged();
+
+        if (!m_mountSuccessEmitted.value(remoteName)) {
+            emit mountFinished(remoteName, false, err.isEmpty() ? QStringLiteral("rclone mount exited unexpectedly.") : err);
+        }
+        m_mountSuccessEmitted.remove(remoteName);
+        proc->deleteLater();
+    });
+
+    connect(proc, &QProcess::errorOccurred, this, [this, remoteName, proc](QProcess::ProcessError) {
+        const QString err = proc->errorString();
+        m_processes.remove(remoteName);
+        emit activeMountsChanged();
+
+        if (!m_mountSuccessEmitted.value(remoteName)) {
+            emit mountFinished(remoteName, false, err);
+        }
+        m_mountSuccessEmitted.remove(remoteName);
+        proc->deleteLater();
+    });
+
+    proc->start(QStringLiteral("rclone"), {
+        QStringLiteral("mount"),
+        remoteName + QStringLiteral(":"),
+        mountPath,
+        QStringLiteral("--vfs-cache-mode"),
+        QStringLiteral("writes"),
+        QStringLiteral("--vfs-cache-max-age"),
+        QStringLiteral("72h"),
+        QStringLiteral("--dir-cache-time"),
+        QStringLiteral("72h"),
+        QStringLiteral("--attr-timeout"),
+        QStringLiteral("72h"),
+        QStringLiteral("--no-checksum"),
+        QStringLiteral("--vfs-read-chunk-size"),
+        QStringLiteral("1M"),
+        QStringLiteral("--vfs-read-chunk-size-limit"),
+        QStringLiteral("off"),
+        QStringLiteral("--buffer-size"),
+        QStringLiteral("32M"),
+        QStringLiteral("--poll-interval"),
+        QStringLiteral("15s"),
+        QStringLiteral("-o"),
+        QStringLiteral("big_writes")
+    });
+
+    // Poll mountpoint checks every 100ms to verify FUSE mount is active
+    QTimer *mountTimer = new QTimer(this);
+    connect(mountTimer, &QTimer::timeout, this, [this, remoteName, mountPath, mountTimer]() {
+        if (!m_processes.contains(remoteName) || m_processes.value(remoteName)->state() != QProcess::Running) {
+            mountTimer->stop();
+            mountTimer->deleteLater();
+            return;
+        }
+
+        struct stat st_dir, st_parent;
+        QString parentPath = QDir(mountPath).filePath(QStringLiteral(".."));
+        if (stat(mountPath.toLocal8Bit().constData(), &st_dir) == 0 &&
+            stat(parentPath.toLocal8Bit().constData(), &st_parent) == 0) {
+
+            if (st_dir.st_dev != st_parent.st_dev) {
+                mountTimer->stop();
+                mountTimer->deleteLater();
+
+                m_mountSuccessEmitted[remoteName] = true;
+                emit mountFinished(remoteName, true, QString());
+            }
+        }
+    });
+
+    // Timeout safety: if it doesn't mount in 10 seconds, abort
+    QTimer::singleShot(10000, this, [this, remoteName, mountTimer]() {
+        if (m_processes.contains(remoteName) && !m_mountSuccessEmitted.value(remoteName)) {
+            mountTimer->stop();
+            mountTimer->deleteLater();
+
+            unmountRemote(remoteName);
+            emit mountFinished(remoteName, false, QStringLiteral("Mount operation timed out. Verify your rclone remote or network connection."));
+        }
+    });
+
+    mountTimer->start(100);
+}
+
+void RcloneService::unmountRemote(const QString &remoteName)
+{
+    if (!m_processes.contains(remoteName)) {
+        emit unmountFinished(remoteName, true);
+        return;
+    }
+
+    QProcess *proc = m_processes.value(remoteName);
+    if (proc) {
+        disconnect(proc, nullptr, this, nullptr);
+        proc->terminate();
+        if (!proc->waitForFinished(2000)) {
+            proc->kill();
+        }
+        proc->deleteLater();
+    }
+
+    m_processes.remove(remoteName);
+    m_mountSuccessEmitted.remove(remoteName);
+    emit activeMountsChanged();
+
+    // Call fusermount -u to cleanly release FUSE mount points (standard on Linux)
+    const QString mountPath = getMountPath(remoteName);
+    QProcess unmountProc;
+    unmountProc.start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
+    if (!unmountProc.waitForFinished(2000) || unmountProc.exitCode() != 0) {
+        // Fallback to fusermount3 if standard fusermount fails
+        QProcess unmountProc3;
+        unmountProc3.start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
+        unmountProc3.waitForFinished(2000);
+    }
+
+    emit unmountFinished(remoteName, true);
+}

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -121,24 +121,47 @@ void RcloneService::mountRemote(const QString &remoteName)
     const QString mountPath = getMountPath(remoteName);
     QDir().mkpath(mountPath);
 
-    // Clean up any stale or lingering FUSE mounts asynchronously before starting
-    QProcess *unmountProc = new QProcess(this);
-    connect(unmountProc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
-            [this, remoteName, mountPath, unmountProc](int exitCode) {
-        unmountProc->deleteLater();
-        if (exitCode != 0) {
-            QProcess *unmountProc3 = new QProcess(this);
-            connect(unmountProc3, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
-                    [this, remoteName, mountPath, unmountProc3](int) {
-                unmountProc3->deleteLater();
-                startRcloneMountProcess(remoteName, mountPath);
-            });
-            unmountProc3->start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
-        } else {
-            startRcloneMountProcess(remoteName, mountPath);
-        }
+    // Clear any stale mount left behind by an earlier run before starting.
+    releaseMountPoint(mountPath, [this, remoteName, mountPath]() {
+        startRcloneMountProcess(remoteName, mountPath);
     });
-    unmountProc->start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
+}
+
+// fusermount(1) belongs to libfuse2 and fusermount3(1) to libfuse3; a distro
+// ships one, the other, or neither. Try both and continue either way: a
+// cleanup that cannot run is no reason to strand the caller, and a missing
+// binary emits errorOccurred rather than finished, so a chain hung off
+// finished alone would simply stop here and never call anybody back.
+void RcloneService::releaseMountPoint(const QString &mountPath, const std::function<void()> &then)
+{
+    runUnmountTool(QStringLiteral("fusermount"), mountPath, [this, mountPath, then](bool ok) {
+        if (ok) {
+            then();
+            return;
+        }
+        runUnmountTool(QStringLiteral("fusermount3"), mountPath, [then](bool) { then(); });
+    });
+}
+
+void RcloneService::runUnmountTool(const QString &tool, const QString &mountPath,
+                                   const std::function<void(bool)> &done)
+{
+    QProcess *proc = new QProcess(this);
+    const auto settle = [proc, done](bool ok) {
+        proc->disconnect();
+        proc->deleteLater();
+        done(ok);
+    };
+
+    connect(proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+            [settle](int exitCode, QProcess::ExitStatus status) {
+        settle(status == QProcess::NormalExit && exitCode == 0);
+    });
+    connect(proc, &QProcess::errorOccurred, this, [settle](QProcess::ProcessError) {
+        settle(false);
+    });
+
+    proc->start(tool, {QStringLiteral("-u"), mountPath});
 }
 
 void RcloneService::startRcloneMountProcess(const QString &remoteName, const QString &mountPath)
@@ -259,23 +282,8 @@ void RcloneService::unmountRemote(const QString &remoteName)
     m_mountSuccessEmitted.remove(remoteName);
     emit activeMountsChanged();
 
-    // Call fusermount asynchronously to release FUSE mount points
-    const QString mountPath = getMountPath(remoteName);
-    QProcess *unmountProc = new QProcess(this);
-    connect(unmountProc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
-            [this, remoteName, mountPath, unmountProc](int exitCode) {
-        unmountProc->deleteLater();
-        if (exitCode != 0) {
-            QProcess *unmountProc3 = new QProcess(this);
-            connect(unmountProc3, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
-                    [this, remoteName, unmountProc3](int) {
-                unmountProc3->deleteLater();
-                emit unmountFinished(remoteName, true);
-            });
-            unmountProc3->start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
-        } else {
-            emit unmountFinished(remoteName, true);
-        }
+    // Release the FUSE mount point without blocking the UI.
+    releaseMountPoint(getMountPath(remoteName), [this, remoteName]() {
+        emit unmountFinished(remoteName, true);
     });
-    unmountProc->start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
 }

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -49,31 +49,6 @@ void RcloneService::ensureMountsBaseDirExists() const
     QDir().mkpath(m_mountsBaseDir);
 }
 
-QStringList RcloneService::getRemotes()
-{
-    if (!m_rcloneAvailable)
-        return {};
-
-    QProcess proc;
-    proc.start(QStringLiteral("rclone"), {QStringLiteral("listremotes")});
-    if (proc.waitForFinished(3000)) {
-        QString out = QString::fromUtf8(proc.readAllStandardOutput());
-        QStringList list;
-        const QStringList lines = out.split(QLatin1Char('\n'));
-        for (const QString &line : lines) {
-            QString trimmed = line.trimmed();
-            if (trimmed.endsWith(QLatin1Char(':'))) {
-                trimmed.chop(1);
-            }
-            if (!trimmed.isEmpty()) {
-                list.append(trimmed);
-            }
-        }
-        return list;
-    }
-    return {};
-}
-
 bool RcloneService::isRclonePath(const QString &path) const
 {
     const QString prefix = m_mountsBaseDir + QStringLiteral("/");
@@ -138,15 +113,28 @@ void RcloneService::mountRemote(const QString &remoteName)
     const QString mountPath = getMountPath(remoteName);
     QDir().mkpath(mountPath);
 
-    // Clean up any stale or lingering FUSE mounts from previous sessions/crashes
-    QProcess unmountProc;
-    unmountProc.start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
-    if (!unmountProc.waitForFinished(500) || unmountProc.exitCode() != 0) {
-        QProcess unmountProc3;
-        unmountProc3.start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
-        unmountProc3.waitForFinished(500);
-    }
+    // Clean up any stale or lingering FUSE mounts asynchronously before starting
+    QProcess *unmountProc = new QProcess(this);
+    connect(unmountProc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+            [this, remoteName, mountPath, unmountProc](int exitCode) {
+        unmountProc->deleteLater();
+        if (exitCode != 0) {
+            QProcess *unmountProc3 = new QProcess(this);
+            connect(unmountProc3, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+                    [this, remoteName, mountPath, unmountProc3](int) {
+                unmountProc3->deleteLater();
+                startRcloneMountProcess(remoteName, mountPath);
+            });
+            unmountProc3->start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
+        } else {
+            startRcloneMountProcess(remoteName, mountPath);
+        }
+    });
+    unmountProc->start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
+}
 
+void RcloneService::startRcloneMountProcess(const QString &remoteName, const QString &mountPath)
+{
     QProcess *proc = new QProcess(this);
     m_processes.insert(remoteName, proc);
     m_mountSuccessEmitted[remoteName] = false;
@@ -250,27 +238,36 @@ void RcloneService::unmountRemote(const QString &remoteName)
     QProcess *proc = m_processes.value(remoteName);
     if (proc) {
         disconnect(proc, nullptr, this, nullptr);
+        connect(proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), proc, &QObject::deleteLater);
         proc->terminate();
-        if (!proc->waitForFinished(2000)) {
-            proc->kill();
-        }
-        proc->deleteLater();
+        QTimer::singleShot(2000, proc, [proc]() {
+            if (proc->state() != QProcess::NotRunning) {
+                proc->kill();
+            }
+        });
     }
 
     m_processes.remove(remoteName);
     m_mountSuccessEmitted.remove(remoteName);
     emit activeMountsChanged();
 
-    // Call fusermount -u to cleanly release FUSE mount points (standard on Linux)
+    // Call fusermount asynchronously to release FUSE mount points
     const QString mountPath = getMountPath(remoteName);
-    QProcess unmountProc;
-    unmountProc.start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
-    if (!unmountProc.waitForFinished(2000) || unmountProc.exitCode() != 0) {
-        // Fallback to fusermount3 if standard fusermount fails
-        QProcess unmountProc3;
-        unmountProc3.start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
-        unmountProc3.waitForFinished(2000);
-    }
-
-    emit unmountFinished(remoteName, true);
+    QProcess *unmountProc = new QProcess(this);
+    connect(unmountProc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+            [this, remoteName, mountPath, unmountProc](int exitCode) {
+        unmountProc->deleteLater();
+        if (exitCode != 0) {
+            QProcess *unmountProc3 = new QProcess(this);
+            connect(unmountProc3, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
+                    [this, remoteName, unmountProc3](int) {
+                unmountProc3->deleteLater();
+                emit unmountFinished(remoteName, true);
+            });
+            unmountProc3->start(QStringLiteral("fusermount3"), {QStringLiteral("-u"), mountPath});
+        } else {
+            emit unmountFinished(remoteName, true);
+        }
+    });
+    unmountProc->start(QStringLiteral("fusermount"), {QStringLiteral("-u"), mountPath});
 }

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -10,10 +10,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-namespace {
-    QHash<QString, bool> m_mountSuccessEmitted;
-}
-
 RcloneService::RcloneService(QObject *parent)
     : QObject(parent)
 {

--- a/src/services/rcloneservice.cpp
+++ b/src/services/rcloneservice.cpp
@@ -76,23 +76,18 @@ QStringList RcloneService::getRemotes()
 
 bool RcloneService::isRclonePath(const QString &path) const
 {
-    if (!path.startsWith(m_mountsBaseDir))
-        return false;
-
-    if (path.length() <= m_mountsBaseDir.length())
-        return false;
-
-    QString sub = path.mid(m_mountsBaseDir.length());
-    if (sub.startsWith(QLatin1Char('/'))) {
-        sub = sub.mid(1);
-    }
-
-    return !sub.isEmpty();
+    const QString prefix = m_mountsBaseDir + QStringLiteral("/");
+    return path.startsWith(prefix) && path.length() > prefix.length();
 }
 
 bool RcloneService::isMounted(const QString &remoteName) const
 {
-    return m_processes.contains(remoteName);
+    return m_processes.contains(remoteName) && m_mountSuccessEmitted.value(remoteName);
+}
+
+bool RcloneService::isMounting(const QString &remoteName) const
+{
+    return m_processes.contains(remoteName) && !m_mountSuccessEmitted.value(remoteName);
 }
 
 bool RcloneService::isMountedForPath(const QString &path) const
@@ -133,6 +128,10 @@ void RcloneService::mountRemote(const QString &remoteName)
 
     if (isMounted(remoteName)) {
         emit mountFinished(remoteName, true, QString());
+        return;
+    }
+
+    if (isMounting(remoteName)) {
         return;
     }
 

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -6,6 +6,8 @@
 #include <QHash>
 #include <QProcess>
 
+#include <functional>
+
 class RcloneService : public QObject
 {
     Q_OBJECT
@@ -38,6 +40,9 @@ private:
     bool checkRcloneAvailable() const;
     void ensureMountsBaseDirExists() const;
     void startRcloneMountProcess(const QString &remoteName, const QString &mountPath);
+    void releaseMountPoint(const QString &mountPath, const std::function<void()> &then);
+    void runUnmountTool(const QString &tool, const QString &mountPath,
+                        const std::function<void(bool)> &done);
 
     bool m_rcloneAvailable;
     QString m_mountsBaseDir;

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QHash>
+#include <QProcess>
+
+class RcloneService : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool rcloneAvailable READ rcloneAvailable NOTIFY rcloneAvailableChanged)
+    Q_PROPERTY(QStringList activeMounts READ activeMounts NOTIFY activeMountsChanged)
+
+public:
+    explicit RcloneService(QObject *parent = nullptr);
+    ~RcloneService();
+
+    bool rcloneAvailable() const;
+    QStringList activeMounts() const;
+
+    Q_INVOKABLE QStringList getRemotes();
+    Q_INVOKABLE bool isRclonePath(const QString &path) const;
+    Q_INVOKABLE bool isMounted(const QString &remoteName) const;
+    Q_INVOKABLE bool isMountedForPath(const QString &path) const;
+    Q_INVOKABLE void mountRemote(const QString &remoteName);
+    Q_INVOKABLE void unmountRemote(const QString &remoteName);
+    Q_INVOKABLE QString getMountPath(const QString &remoteName) const;
+    Q_INVOKABLE QString getRemoteNameFromPath(const QString &path) const;
+
+signals:
+    void rcloneAvailableChanged();
+    void activeMountsChanged();
+    void mountFinished(const QString &remoteName, bool success, const QString &errorString);
+    void unmountFinished(const QString &remoteName, bool success);
+
+private:
+    bool checkRcloneAvailable() const;
+    void ensureMountsBaseDirExists() const;
+
+    bool m_rcloneAvailable;
+    QString m_mountsBaseDir;
+    QHash<QString, QProcess*> m_processes;
+};

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -19,7 +19,6 @@ public:
     bool rcloneAvailable() const;
     QStringList activeMounts() const;
 
-    Q_INVOKABLE QStringList getRemotes();
     Q_INVOKABLE bool isRclonePath(const QString &path) const;
     Q_INVOKABLE bool isMounted(const QString &remoteName) const;
     Q_INVOKABLE bool isMounting(const QString &remoteName) const;
@@ -38,6 +37,7 @@ signals:
 private:
     bool checkRcloneAvailable() const;
     void ensureMountsBaseDirExists() const;
+    void startRcloneMountProcess(const QString &remoteName, const QString &mountPath);
 
     bool m_rcloneAvailable;
     QString m_mountsBaseDir;

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -22,6 +22,7 @@ public:
     Q_INVOKABLE QStringList getRemotes();
     Q_INVOKABLE bool isRclonePath(const QString &path) const;
     Q_INVOKABLE bool isMounted(const QString &remoteName) const;
+    Q_INVOKABLE bool isMounting(const QString &remoteName) const;
     Q_INVOKABLE bool isMountedForPath(const QString &path) const;
     Q_INVOKABLE void mountRemote(const QString &remoteName);
     Q_INVOKABLE void unmountRemote(const QString &remoteName);

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -42,4 +42,5 @@ private:
     bool m_rcloneAvailable;
     QString m_mountsBaseDir;
     QHash<QString, QProcess*> m_processes;
+    QHash<QString, bool> m_mountSuccessEmitted;
 };

--- a/src/services/rcloneservice.h
+++ b/src/services/rcloneservice.h
@@ -48,4 +48,7 @@ private:
     QString m_mountsBaseDir;
     QHash<QString, QProcess*> m_processes;
     QHash<QString, bool> m_mountSuccessEmitted;
+    // Bumped per mount attempt so a timeout fired for an abandoned attempt
+    // cannot tear down the mount that replaced it.
+    QHash<QString, quint64> m_mountGeneration;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,6 +207,7 @@ add_executable(tst_mainwindow tst_mainwindow.cpp
     ${CMAKE_SOURCE_DIR}/src/services/previewservice.cpp
     ${CMAKE_SOURCE_DIR}/src/services/diskusageservice.cpp
     ${CMAKE_SOURCE_DIR}/src/services/remoteaccessservice.cpp
+    ${CMAKE_SOURCE_DIR}/src/services/rcloneservice.cpp
     ${CMAKE_SOURCE_DIR}/src/services/runtimefeaturesservice.cpp
     ${CMAKE_SOURCE_DIR}/src/services/dependencychecker.cpp
     ${CMAKE_SOURCE_DIR}/src/services/gitstatusservice.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,13 @@ target_include_directories(tst_previewservice PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(tst_previewservice PRIVATE Qt6::Test Qt6::Core Qt6::Gui)
 add_test(NAME tst_previewservice COMMAND tst_previewservice)
 
+add_executable(tst_rcloneservice tst_rcloneservice.cpp
+    ${CMAKE_SOURCE_DIR}/src/services/rcloneservice.cpp
+)
+target_include_directories(tst_rcloneservice PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(tst_rcloneservice PRIVATE Qt6::Test Qt6::Core)
+add_test(NAME tst_rcloneservice COMMAND tst_rcloneservice)
+
 add_executable(tst_remoteaccessservice tst_remoteaccessservice.cpp
     ${CMAKE_SOURCE_DIR}/src/services/remoteaccessservice.cpp
 )

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -32,6 +32,7 @@
 #include "services/metadataextractor.h"
 #include "services/previewservice.h"
 #include "services/remoteaccessservice.h"
+#include "services/rcloneservice.h"
 #include "services/runtimefeaturesservice.h"
 #include "services/searchservice.h"
 #include "services/sessionstate.h"
@@ -97,6 +98,7 @@ class TestMainWindow : public QObject
             auto *metadataExtractor = new MetadataExtractor(&owner);
             auto *diskUsageService = new DiskUsageService(&owner);
             auto *remoteAccessService = new RemoteAccessService(&owner);
+            auto *rcloneService = new RcloneService(&owner);
             auto *runtimeFeatures = new RuntimeFeaturesService(&owner);
             auto *recentFiles = new RecentFilesModel(configDir + "/recents.json", &owner);
             auto *devices = new DeviceModel(&owner, true);
@@ -135,6 +137,7 @@ class TestMainWindow : public QObject
             ctx->setContextProperty("metadataExtractor", metadataExtractor);
             ctx->setContextProperty("diskUsageService", diskUsageService);
             ctx->setContextProperty("remoteAccessService", remoteAccessService);
+            ctx->setContextProperty("rcloneService", rcloneService);
             ctx->setContextProperty("runtimeFeatures", runtimeFeatures);
             ctx->setContextProperty("dependencies", dependencies);
             ctx->setContextProperty("sessionState", sessionState);

--- a/tests/tst_rcloneservice.cpp
+++ b/tests/tst_rcloneservice.cpp
@@ -1,0 +1,98 @@
+#include <QDir>
+#include <QTest>
+#include <QSignalSpy>
+#include "services/cloudmounts.h"
+#include "services/rcloneservice.h"
+
+class TestRcloneService : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // Every navigation runs through isRclonePath(), and the whole cloud path
+    // handling -- skipped previews, skipped git status, faked metadata --
+    // hangs off it. Getting the boundaries wrong either mounts on ordinary
+    // folders or silently treats a mount as local.
+    void testOnlyPathsInsideAMountCountAsCloud_data()
+    {
+        QTest::addColumn<QString>("path");
+        QTest::addColumn<bool>("expected");
+
+        const QString base = cloudMountsBaseDir();
+        QTest::newRow("inside a remote") << base + "/gdrive/photos/a.jpg" << true;
+        QTest::newRow("the remote itself") << base + "/gdrive" << true;
+        QTest::newRow("the mounts folder") << base << false;
+        QTest::newRow("mounts folder with slash") << base + "/" << false;
+        QTest::newRow("a sibling folder") << base + "-backup/gdrive" << false;
+        QTest::newRow("an ordinary path") << QStringLiteral("/home/user/Documents") << false;
+        QTest::newRow("empty") << QString() << false;
+    }
+
+    void testOnlyPathsInsideAMountCountAsCloud()
+    {
+        QFETCH(QString, path);
+        QFETCH(bool, expected);
+
+        RcloneService service;
+        QCOMPARE(service.isRclonePath(path), expected);
+        QCOMPARE(isCloudMountPath(path), expected);
+    }
+
+    void testRemoteNameIsTheFirstSegmentUnderTheMountsFolder()
+    {
+        RcloneService service;
+        const QString base = cloudMountsBaseDir();
+
+        QCOMPARE(service.getRemoteNameFromPath(base + "/gdrive"), QString("gdrive"));
+        QCOMPARE(service.getRemoteNameFromPath(base + "/gdrive/photos/a.jpg"), QString("gdrive"));
+        QCOMPARE(service.getRemoteNameFromPath(base), QString());
+        QCOMPARE(service.getRemoteNameFromPath("/home/user/Documents"), QString());
+    }
+
+    void testMountPathRoundTripsThroughTheRemoteName()
+    {
+        RcloneService service;
+        const QString mountPath = service.getMountPath(QStringLiteral("onedrive"));
+
+        QCOMPARE(mountPath, cloudMountsBaseDir() + "/onedrive");
+        QVERIFY(service.isRclonePath(mountPath));
+        QCOMPARE(service.getRemoteNameFromPath(mountPath), QString("onedrive"));
+    }
+
+    // A remote nobody has mounted must not report itself as mounted or
+    // mounting: Main.qml reads both before deciding whether to navigate
+    // straight away or park the navigation behind a mount.
+    void testAnUnknownRemoteIsNeitherMountedNorMounting()
+    {
+        RcloneService service;
+
+        QVERIFY(!service.isMounted(QStringLiteral("nosuchremote")));
+        QVERIFY(!service.isMounting(QStringLiteral("nosuchremote")));
+        QVERIFY(!service.isMountedForPath(cloudMountsBaseDir() + "/nosuchremote/file.txt"));
+        QVERIFY(service.activeMounts().isEmpty());
+    }
+
+    // The navigation that asked for the mount is only released by
+    // mountFinished, so a mount that cannot even start has to report failure
+    // rather than leave the pane waiting forever.
+    void testMountingAnUnknownRemoteReportsFailure()
+    {
+        RcloneService service;
+        QSignalSpy finished(&service, &RcloneService::mountFinished);
+
+        service.mountRemote(QStringLiteral("hyprfm-test-nosuchremote"));
+
+        QTRY_VERIFY_WITH_TIMEOUT(finished.count() == 1, 20000);
+        QCOMPARE(finished.at(0).at(0).toString(), QString("hyprfm-test-nosuchremote"));
+        QCOMPARE(finished.at(0).at(1).toBool(), false);
+        QVERIFY(!finished.at(0).at(2).toString().isEmpty());
+        QVERIFY(!service.isMounted(QStringLiteral("hyprfm-test-nosuchremote")));
+
+        // mountRemote() creates the mount point before it knows the mount
+        // will fail; don't leave it behind in the user's home.
+        QDir().rmdir(service.getMountPath(QStringLiteral("hyprfm-test-nosuchremote")));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestRcloneService)
+#include "tst_rcloneservice.moc"

--- a/tests/viewharness.h
+++ b/tests/viewharness.h
@@ -22,6 +22,7 @@ class FileOpsStub : public QObject
 public:
     QStringList pendingTargetPaths() const { return {}; }
     Q_INVOKABLE bool isRemotePath(const QString &) const { return false; }
+    Q_INVOKABLE bool isSlowPath(const QString &) const { return false; }
     Q_INVOKABLE bool isArchive(const QString &) const { return false; }
 };
 


### PR DESCRIPTION
### Summary
Implements the background Rclone mounting service and essential optimizations for cloud paths.

### Key Changes
- **Rclone Background Mounts:** Added a C++ service to manage background mounts and registered `rclone` as an optional runtime dependency.
- **Git Status & FUSE Bypass:** Disabled Git status checks for files inside the cloud mounts directory to prevent UI freezes.
- **Performance Optimizations:** Bypassed slow synchronous metadata (disk usage, ownership, permissions) and disabled content-based MIME sniffing on cloud paths.
- **UI Integration:** Added a folder loading spinner to the status bar and implemented automatic mount triggers upon navigation.