### PR TITLE
feat: unlock password-protected archives on extract and preview

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ list(APPEND hyprfm_qml_module_args
         qml/views/KineticWheelScroller.qml
         qml/components/ContextMenu.qml
         qml/components/BulkRenameDialog.qml
+        qml/components/ArchivePasswordDialog.qml
         qml/components/RemoteConnectDialog.qml
         qml/components/PreviewLoader.qml
         qml/components/QuickPreview.qml

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -41,6 +41,9 @@ ApplicationWindow {
     property string transferDestinationPath: ""
     property var transferReservedTargets: ({})
     property bool paneFocusScheduled: false
+    // Archive being unlocked right now; {path, dest}. dest is empty when the
+    // password only feeds the preview (QuickPreview refresh).
+    property var passwordDialogContext: null
     readonly property string unifiedTrashPath: "trash:///"
     readonly property bool isTrashView: fileOps.isTrashPath(panePath(activePane))
     readonly property bool isRemoteView: fileOps.isRemotePath(panePath(activePane))
@@ -1247,6 +1250,12 @@ ApplicationWindow {
     BulkRenameDialog {
         id: bulkRenameDialog
         onRenameApplied: (paths) => root.handleBulkRenameApplied(paths)
+    }
+
+    ArchivePasswordDialog {
+        id: archivePasswordDialog
+        onConfirmed: (password) => root.handleArchivePasswordConfirmed(password)
+        onRejected: root.passwordDialogContext = null
     }
 
     RemoteConnectDialog {
@@ -3325,20 +3334,41 @@ ApplicationWindow {
             var dest = fileOps.newExtractionFolder(filePath)
             if (!dest)
                 return
-            var opId = fileOps.extractArchive(filePath, dest)
-            if (opId < 0)
-                return
-            var onExtracted = function(success, error, id) {
-                if (id !== opId) return
-                fileOps.operationFinished.disconnect(onExtracted)
-                if (success)
-                    root.navigatePaneTo(pane, dest)
-            }
-            fileOps.operationFinished.connect(onExtracted)
+            root.trackArchiveExtraction(pane, filePath, dest, fileOps.archivePassword(filePath))
         } else {
             fileOps.openFile(filePath)
             recentFiles.addRecent(filePath)
         }
+    }
+
+    // Runs an extraction and navigates the pane into the destination folder
+    // once it succeeds (used by Enter-on-archive and by password retries).
+    function trackArchiveExtraction(pane, archivePath, dest, password) {
+        var opId = fileOps.extractArchive(archivePath, dest, password)
+        if (opId < 0)
+            return
+        var onFinished = function(success, error, id) {
+            if (id !== opId) return
+            fileOps.operationFinished.disconnect(onFinished)
+            if (success) {
+                if (pane)
+                    root.navigatePaneTo(pane, dest)
+                else
+                    root.navigateActivePaneTo(dest)
+            }
+        }
+        fileOps.operationFinished.connect(onFinished)
+    }
+
+    function handleArchivePasswordConfirmed(password) {
+        var ctx = root.passwordDialogContext
+        root.passwordDialogContext = null
+        if (!ctx || !ctx.path)
+            return
+        fileOps.cacheArchivePassword(ctx.path, password)
+        if (ctx.dest)
+            root.trackArchiveExtraction(null, ctx.path, ctx.dest, password)
+        quickPreview.reloadAfterUnlock()
     }
 
     function showContextMenuForPane(pane, filePath, isDirectory, position) {
@@ -3826,6 +3856,10 @@ ApplicationWindow {
                 recentFiles.addRecent(path)
             }
         }
+        onUnlockArchiveRequested: (path) => {
+            root.passwordDialogContext = { path: path, dest: "" }
+            archivePasswordDialog.openFor(path)
+        }
         onClosed: {
             quickPreview.active = false
             root.scheduleActivePaneFocus()
@@ -3848,6 +3882,11 @@ ApplicationWindow {
                 propertiesDialog.refreshFolderDiskUsage()
         }
 
+        function onPasswordRequested(archivePath, destination) {
+            root.passwordDialogContext = { path: archivePath, dest: destination }
+            archivePasswordDialog.openFor(archivePath)
+        }
+
         function onOperationFinished(success, error) {
             fsModel.refresh()
             splitFsModel.refresh()
@@ -3856,6 +3895,8 @@ ApplicationWindow {
                 propertiesDialog.props = propertiesDialog.fileModelRef.fileProperties(propertiesDialog.props.path)
                 propertiesDialog.refreshFolderDiskUsage()
             }
+            if (error === "password required")
+                return  // the password dialog handles it
             if (success)
                 toast.show("Operation completed successfully", "success")
             else

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -3368,7 +3368,11 @@ ApplicationWindow {
         fileOps.cacheArchivePassword(ctx.path, password)
         if (ctx.dest)
             root.trackArchiveExtraction(null, ctx.path, ctx.dest, password)
-        quickPreview.reloadAfterUnlock()
+        // Only when the preview is actually on screen: the dialog also opens
+        // from an extraction, where reloading would run a preview nobody asked
+        // for, on whatever file the closed overlay was last pointed at.
+        if (quickPreview.active)
+            quickPreview.reloadAfterUnlock()
     }
 
     function showContextMenuForPane(pane, filePath, isDirectory, position) {
@@ -3858,7 +3862,7 @@ ApplicationWindow {
         }
         onUnlockArchiveRequested: (path) => {
             root.passwordDialogContext = { path: path, dest: "" }
-            archivePasswordDialog.openFor(path)
+            archivePasswordDialog.openFor(path, false)
         }
         onClosed: {
             quickPreview.active = false
@@ -3882,9 +3886,9 @@ ApplicationWindow {
                 propertiesDialog.refreshFolderDiskUsage()
         }
 
-        function onPasswordRequested(archivePath, destination) {
+        function onPasswordRequested(archivePath, destination, retry) {
             root.passwordDialogContext = { path: archivePath, dest: destination }
-            archivePasswordDialog.openFor(archivePath)
+            archivePasswordDialog.openFor(archivePath, retry)
         }
 
         function onOperationFinished(success, error) {

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -1254,6 +1254,7 @@ ApplicationWindow {
 
     ArchivePasswordDialog {
         id: archivePasswordDialog
+        objectName: "archivePasswordDialog"
         onConfirmed: (password) => root.handleArchivePasswordConfirmed(password)
         onRejected: root.passwordDialogContext = null
     }
@@ -3860,9 +3861,9 @@ ApplicationWindow {
                 recentFiles.addRecent(path)
             }
         }
-        onUnlockArchiveRequested: (path) => {
+        onUnlockArchiveRequested: (path, retry) => {
             root.passwordDialogContext = { path: path, dest: "" }
-            archivePasswordDialog.openFor(path, false)
+            archivePasswordDialog.openFor(path, retry)
         }
         onClosed: {
             quickPreview.active = false

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -3352,6 +3352,12 @@ ApplicationWindow {
             if (id !== opId) return
             fileOps.operationFinished.disconnect(onFinished)
             if (success) {
+                // Whatever password got us here was the right one, so the
+                // prompt (still open while it was being proved) is done.
+                if (archivePasswordDialog.visible) {
+                    root.passwordDialogContext = null
+                    archivePasswordDialog.succeeded()
+                }
                 if (pane)
                     root.navigatePaneTo(pane, dest)
                 else
@@ -3361,9 +3367,20 @@ ApplicationWindow {
         fileOps.operationFinished.connect(onFinished)
     }
 
+    // Asking may be a first ask (open the dialog) or the answer to one the
+    // user just gave (report into the dialog already up, without closing it).
+    function askArchivePassword(path, dest, retry) {
+        root.passwordDialogContext = { path: path, dest: dest }
+        if (retry && archivePasswordDialog.visible)
+            archivePasswordDialog.failed()
+        else
+            archivePasswordDialog.openFor(path)
+    }
+
     function handleArchivePasswordConfirmed(password) {
+        // Kept, not cleared: the dialog stays open until the password is
+        // proved, and a refusal asks again for this same archive.
         var ctx = root.passwordDialogContext
-        root.passwordDialogContext = null
         if (!ctx || !ctx.path)
             return
         fileOps.cacheArchivePassword(ctx.path, password)
@@ -3862,8 +3879,11 @@ ApplicationWindow {
             }
         }
         onUnlockArchiveRequested: (path, retry) => {
-            root.passwordDialogContext = { path: path, dest: "" }
-            archivePasswordDialog.openFor(path, retry)
+            root.askArchivePassword(path, "", retry)
+        }
+        onUnlockSucceeded: {
+            root.passwordDialogContext = null
+            archivePasswordDialog.succeeded()
         }
         onClosed: {
             quickPreview.active = false
@@ -3888,8 +3908,7 @@ ApplicationWindow {
         }
 
         function onPasswordRequested(archivePath, destination, retry) {
-            root.passwordDialogContext = { path: archivePath, dest: destination }
-            archivePasswordDialog.openFor(archivePath, retry)
+            root.askArchivePassword(archivePath, destination, retry)
         }
 
         function onOperationFinished(success, error) {

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -599,24 +599,17 @@ ApplicationWindow {
         // Wait for this operation's id, not for whichever transfer finishes
         // next; several can run at once.
         var opId = -1
-        var onFinished = null
-        if (clearClipboardOnSuccess) {
-            onFinished = function(success, error, id) {
-                if (id !== opId) return
-                fileOps.operationFinished.disconnect(onFinished)
-                if (success)
-                    clipboard.clear()
-            }
-            fileOps.operationFinished.connect(onFinished)
-        }
-
         if (usesRemotePath)
             opId = moveOperation ? fileOps.moveResolvedItems(items) : fileOps.copyResolvedItems(items)
         else
             opId = moveOperation ? undoManager.moveResolvedItems(items) : undoManager.copyResolvedItems(items)
 
-        if (onFinished && opId < 0)   // failed before it started; nothing will call back
-            fileOps.operationFinished.disconnect(onFinished)
+        if (clearClipboardOnSuccess) {
+            root.whenOperationFinishes(opId, function(success, error) {
+                if (success)
+                    clipboard.clear()
+            })
+        }
     }
 
     function openTransferConflict(index) {
@@ -3322,6 +3315,21 @@ ApplicationWindow {
         return []
     }
 
+    // Callbacks waiting on one operation's id. A JS
+    // fileOps.operationFinished.connect(function(success, error, id)) never
+    // receives that third argument — only a Connections handler does — so
+    // every such callback compared `undefined` against its id and silently
+    // never ran. Everything waiting on a specific operation goes through here.
+    property var _operationCallbacks: ({})
+
+    function whenOperationFinishes(opId, callback) {
+        if (opId < 0)
+            return
+        var pending = root._operationCallbacks
+        pending[opId] = callback
+        root._operationCallbacks = pending
+    }
+
     function handlePaneFileActivated(pane, filePath, isDirectory) {
         root.setActivePane(pane)
 
@@ -3348,9 +3356,7 @@ ApplicationWindow {
         var opId = fileOps.extractArchive(archivePath, dest, password)
         if (opId < 0)
             return
-        var onFinished = function(success, error, id) {
-            if (id !== opId) return
-            fileOps.operationFinished.disconnect(onFinished)
+        root.whenOperationFinishes(opId, function(success, error) {
             if (success) {
                 // Whatever password got us here was the right one, so the
                 // prompt (still open while it was being proved) is done.
@@ -3363,8 +3369,7 @@ ApplicationWindow {
                 else
                     root.navigateActivePaneTo(dest)
             }
-        }
-        fileOps.operationFinished.connect(onFinished)
+        })
     }
 
     // Asking may be a first ask (open the dialog) or the answer to one the
@@ -3911,10 +3916,18 @@ ApplicationWindow {
             root.askArchivePassword(archivePath, destination, retry)
         }
 
-        function onOperationFinished(success, error) {
+        function onOperationFinished(success, error, operationId) {
             fsModel.refresh()
             splitFsModel.refresh()
             root.updateSelectionStatus()
+
+            var waiting = root._operationCallbacks[operationId]
+            if (waiting !== undefined) {
+                var pending = root._operationCallbacks
+                delete pending[operationId]
+                root._operationCallbacks = pending
+                waiting(success, error)
+            }
             if (propertiesDialog.visible && propertiesDialog.props.path) {
                 propertiesDialog.props = propertiesDialog.fileModelRef.fileProperties(propertiesDialog.props.path)
                 propertiesDialog.refreshFolderDiskUsage()

--- a/src/qml/components/ArchivePasswordDialog.qml
+++ b/src/qml/components/ArchivePasswordDialog.qml
@@ -19,25 +19,47 @@ Q.Dialog {
         return parts[parts.length - 1] || root.filePath
     }
     property string errorText: ""
+    // A password has been handed over and we are waiting to hear whether it
+    // worked. The dialog stays up throughout: closing and reopening it on a
+    // wrong password reads as a flicker and loses what you typed.
+    property bool checking: false
 
     signal confirmed(string password)
 
-    function openFor(path, retry) {
+    function openFor(path) {
         root.filePath = path
-        root.errorText = retry ? "That password did not work. Try again." : ""
+        root.errorText = ""
+        root.checking = false
         passwordField.text = ""
         root.open()
     }
 
+    // The password was refused. Stay open, say so, and offer the field back
+    // with the failed attempt selected so typing replaces it.
+    function failed() {
+        root.checking = false
+        root.errorText = "Wrong password. Try again."
+        passwordField.inputItem.forceActiveFocus()
+        passwordField.inputItem.selectAll()
+    }
+
+    // The password worked; nothing left to ask.
+    function succeeded() {
+        root.checking = false
+        root.accept()
+    }
+
     function submit() {
+        if (root.checking)
+            return
         root.errorText = ""
         var pass = passwordField.text
         if (pass === "") {
             root.errorText = "Enter the archive password."
             return
         }
+        root.checking = true
         root.confirmed(pass)
-        root.accept()
     }
 
     onOpened: Qt.callLater(function() { passwordField.inputItem.forceActiveFocus() })
@@ -48,6 +70,7 @@ Q.Dialog {
         variant: "filled"
         placeholder: "Password"
         echoMode: TextInput.Password
+        enabled: !root.checking
         inputItem.Keys.onReturnPressed: root.submit()
         onTextChanged: root.errorText = ""
     }
@@ -73,9 +96,10 @@ Q.Dialog {
         }
 
         Q.Button {
-            text: "Unlock"
+            text: root.checking ? "Checking\u2026" : "Unlock"
             variant: "primary"
             size: "small"
+            enabled: !root.checking
             onClicked: root.submit()
         }
     }

--- a/src/qml/components/ArchivePasswordDialog.qml
+++ b/src/qml/components/ArchivePasswordDialog.qml
@@ -66,6 +66,7 @@ Q.Dialog {
 
     Q.TextField {
         id: passwordField
+        objectName: "archivePasswordField"
         Layout.fillWidth: true
         variant: "filled"
         placeholder: "Password"

--- a/src/qml/components/ArchivePasswordDialog.qml
+++ b/src/qml/components/ArchivePasswordDialog.qml
@@ -22,9 +22,9 @@ Q.Dialog {
 
     signal confirmed(string password)
 
-    function openFor(path) {
+    function openFor(path, retry) {
         root.filePath = path
-        root.errorText = ""
+        root.errorText = retry ? "That password did not work. Try again." : ""
         passwordField.text = ""
         root.open()
     }

--- a/src/qml/components/ArchivePasswordDialog.qml
+++ b/src/qml/components/ArchivePasswordDialog.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import HyprFM
+import Quill as Q
+
+Q.Dialog {
+    id: root
+    anchors.fill: parent
+    z: 1000
+    dialogWidth: 430
+    title: "Archive password"
+    subtitle: root.fileName
+    initialFocusItem: passwordField
+
+    property string filePath: ""
+    property string fileName: {
+        var parts = String(root.filePath).split("/")
+        return parts[parts.length - 1] || root.filePath
+    }
+    property string errorText: ""
+
+    signal confirmed(string password)
+
+    function openFor(path) {
+        root.filePath = path
+        root.errorText = ""
+        passwordField.text = ""
+        root.open()
+    }
+
+    function submit() {
+        root.errorText = ""
+        var pass = passwordField.text
+        if (pass === "") {
+            root.errorText = "Enter the archive password."
+            return
+        }
+        root.confirmed(pass)
+        root.accept()
+    }
+
+    onOpened: Qt.callLater(function() { passwordField.inputItem.forceActiveFocus() })
+
+    Q.TextField {
+        id: passwordField
+        Layout.fillWidth: true
+        variant: "filled"
+        placeholder: "Password"
+        echoMode: TextInput.Password
+        inputItem.Keys.onReturnPressed: root.submit()
+        onTextChanged: root.errorText = ""
+    }
+
+    Text {
+        Layout.fillWidth: true
+        visible: root.errorText !== ""
+        text: root.errorText
+        color: Theme.error
+        font.pointSize: Theme.fontSmall
+        wrapMode: Text.WordWrap
+    }
+
+    RowLayout {
+        Layout.alignment: Qt.AlignRight
+        spacing: 12
+
+        Q.Button {
+            text: "Cancel"
+            variant: "ghost"
+            size: "small"
+            onClicked: root.reject()
+        }
+
+        Q.Button {
+            text: "Unlock"
+            variant: "primary"
+            size: "small"
+            onClicked: root.submit()
+        }
+    }
+}

--- a/src/qml/components/ContextMenu.qml
+++ b/src/qml/components/ContextMenu.qml
@@ -826,7 +826,7 @@ Item {
         case "compress_tarxz": fileOps.compressFiles(effectivePaths, "tar.xz"); break
         case "compress_tarbz2": fileOps.compressFiles(effectivePaths, "tar.bz2"); break
         case "compress_tar": fileOps.compressFiles(effectivePaths, "tar"); break
-        case "extract": fileOps.extractArchive(targetPath, effectiveDir); break
+        case "extract": fileOps.extractArchive(targetPath, effectiveDir, fileOps.archivePassword(targetPath)); break
         case "setwallpaper": fileOps.setWallpaper(targetPath); break
         case "emptytrash": emptyTrashRequested(); break
         default:

--- a/src/qml/components/PreviewLoader.qml
+++ b/src/qml/components/PreviewLoader.qml
@@ -28,6 +28,10 @@ QtObject {
     // "text" | "pdf" | "archive" | "directory" | "" (metadata only)
     property string kind: ""
 
+    // Only meaningful for encrypted archives. Set by the owner alongside
+    // `path`, and read at dispatch time for the same reason.
+    property string password: ""
+
     // True from dispatch until the matching result lands.
     property bool loading: false
 
@@ -75,7 +79,8 @@ QtObject {
         interval: 80
         onTriggered: {
             loader.loading = loader.kind !== ""
-            previewService.requestPreview(loader.requester, loader.path, loader.kind)
+            previewService.requestPreview(loader.requester, loader.path, loader.kind,
+                                          loader.password)
         }
     }
 

--- a/src/qml/components/QuickPreview.qml
+++ b/src/qml/components/QuickPreview.qml
@@ -36,6 +36,7 @@ Item {
     signal closed()
     signal openRequested(string path, bool isDirectory)
     signal unlockArchiveRequested(string filePath, bool retry)
+    signal unlockSucceeded()
 
     // Set while a password the user just typed is being proved by a reload.
     property bool _unlockPending: false
@@ -57,6 +58,7 @@ Item {
             root.unlockArchiveRequested(root.filePath, true)
         } else if ((directoryPreview.entries || []).length > 0) {
             root._unlockPending = false
+            root.unlockSucceeded()
         }
     }
 

--- a/src/qml/components/QuickPreview.qml
+++ b/src/qml/components/QuickPreview.qml
@@ -35,10 +35,29 @@ Item {
 
     signal closed()
     signal openRequested(string path, bool isDirectory)
-    signal unlockArchiveRequested(string filePath)
+    signal unlockArchiveRequested(string filePath, bool retry)
+
+    // Set while a password the user just typed is being proved by a reload.
+    property bool _unlockPending: false
 
     function reloadAfterUnlock() {
+        root._unlockPending = true
         root.refreshPreviewData()
+    }
+
+    // The preview is the only thing that can tell us a password was wrong on
+    // this path: nothing extracts, so no operation reports back. If the reload
+    // still comes back locked, ask again and say so.
+    onDirectoryPreviewChanged: {
+        if (!root._unlockPending)
+            return
+        if (directoryPreview.requiresPassword === true) {
+            root._unlockPending = false
+            fileOps.clearArchivePassword(root.filePath)
+            root.unlockArchiveRequested(root.filePath, true)
+        } else if ((directoryPreview.entries || []).length > 0) {
+            root._unlockPending = false
+        }
     }
 
     readonly property string fileName: {
@@ -913,7 +932,7 @@ Item {
                                     id: unlockMouse
                                     anchors.fill: parent
                                     hoverEnabled: true
-                                    onClicked: root.unlockArchiveRequested(root.filePath)
+                                    onClicked: root.unlockArchiveRequested(root.filePath, false)
                                 }
                             }
 

--- a/src/qml/components/QuickPreview.qml
+++ b/src/qml/components/QuickPreview.qml
@@ -41,6 +41,18 @@ Item {
     // Set while a password the user just typed is being proved by a reload.
     property bool _unlockPending: false
 
+    // The archive this preview unlocked, if any. The password lives only as
+    // long as the preview showing it, so moving to another file or closing
+    // the overlay forgets it, the way Ark and File Roller do.
+    property string _unlockedPath: ""
+
+    function _forgetUnlockedArchive() {
+        if (root._unlockedPath === "")
+            return
+        fileOps.clearArchivePassword(root._unlockedPath)
+        root._unlockedPath = ""
+    }
+
     function reloadAfterUnlock() {
         root._unlockPending = true
         root.refreshPreviewData()
@@ -58,6 +70,7 @@ Item {
             root.unlockArchiveRequested(root.filePath, true)
         } else if ((directoryPreview.entries || []).length > 0) {
             root._unlockPending = false
+            root._unlockedPath = root.filePath
             root.unlockSucceeded()
         }
     }
@@ -281,6 +294,7 @@ Item {
             openAnim.start()
             Qt.callLater(function() { root.forceActiveFocus() })
         } else if (visible) {
+            root._forgetUnlockedArchive()
             // Closing: stop any in-flight worker from doing pointless work
             // and from repainting a panel the user is no longer looking at.
             previewLoader.stop()
@@ -290,6 +304,9 @@ Item {
         }
     }
     onFilePathChanged: {
+        // Moving to another file ends the unlocked archive's life.
+        if (root._unlockedPath !== "" && root._unlockedPath !== root.filePath)
+            root._forgetUnlockedArchive()
         pdfHoldSource = ""
         pdfPageIndex = 0
         pdfWheelAccumulator = 0

--- a/src/qml/components/QuickPreview.qml
+++ b/src/qml/components/QuickPreview.qml
@@ -35,6 +35,11 @@ Item {
 
     signal closed()
     signal openRequested(string path, bool isDirectory)
+    signal unlockArchiveRequested(string filePath)
+
+    function reloadAfterUnlock() {
+        root.refreshPreviewData()
+    }
 
     readonly property string fileName: {
         if (fileProps.name)
@@ -236,6 +241,10 @@ Item {
             ? previewService.loadFontPreview(filePath)
             : ({ family: "", styleName: "", weight: 400, italic: false, valid: false, error: "" })
 
+        // Assigned, not bound: archivePassword() is a plain invokable with no
+        // NOTIFY, so a binding would never re-evaluate after the user unlocks
+        // the archive. reloadAfterUnlock() routes back through here.
+        previewLoader.password = isArchive ? fileOps.archivePassword(filePath) : ""
         previewLoader.reload()
     }
 
@@ -880,6 +889,32 @@ Item {
                                 color: Theme.error
                                 font.pointSize: Theme.fontNormal
                                 wrapMode: Text.WordWrap
+                            }
+
+                            Rectangle {
+                                Layout.alignment: Qt.AlignHCenter
+                                visible: directoryPreview.requiresPassword === true
+                                implicitWidth: unlockMouse.containsMouse ? 132 : 124
+                                implicitHeight: 32
+                                radius: Theme.radiusMedium
+                                color: unlockMouse.containsMouse
+                                    ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.25)
+                                    : Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.14)
+                                Behavior on implicitWidth { NumberAnimation { duration: 100 } }
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "Enter password"
+                                    color: Theme.text
+                                    font.pointSize: Theme.fontSmall
+                                }
+
+                                MouseArea {
+                                    id: unlockMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    onClicked: root.unlockArchiveRequested(root.filePath)
+                                }
                             }
 
                             Item {

--- a/src/services/archivepassword.h
+++ b/src/services/archivepassword.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+
+// Handed to 7z/unzip whenever no password is known. It is deliberately wrong,
+// and long enough that no real password collides with it: without a -p/-P the
+// tools prompt on stdin and wait forever for input nobody will type, hanging
+// the extraction. With it, an encrypted archive fails immediately and an
+// unencrypted one ignores it.
+inline const QLatin1String archivePasswordSentinel("__hyprfm_placeholder_password__");
+
+inline QString effectiveArchivePassword(const QString &password)
+{
+    return password.isEmpty() ? QString(archivePasswordSentinel) : password;
+}

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -18,6 +18,7 @@
 #include <QSet>
 #include <QStandardPaths>
 #include <QStorageInfo>
+#include <csignal>
 #include <QTemporaryFile>
 #include <QUuid>
 #include <QUrl>
@@ -37,6 +38,56 @@ bool runningInFlatpak()
 {
     static const bool inSandbox = QFile::exists(QStringLiteral("/.flatpak-info"));
     return inSandbox;
+}
+
+// Total size of all regular files under a directory, used to turn raw
+// extraction output into smooth byte-based progress (7z prints no per-file
+// lines, only an in-place percentage that stalls near the end).
+qint64 dirTotalBytes(const QString &dir)
+{
+    qint64 total = 0;
+    QDirIterator it(dir, QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden);
+    while (it.hasNext()) {
+        it.next();
+        const QFileInfo fi = it.fileInfo();
+        if (fi.isSymLink())
+            continue;
+        if (fi.isDir())
+            total += dirTotalBytes(fi.absoluteFilePath());
+        else
+            total += fi.size();
+    }
+    return total;
+}
+
+// Signal a subprocess by its pid (published as an atomic by simple
+// operations) so transfers can be paused, resumed or cancelled from the GUI
+// thread without touching the QProcess object living in the worker thread.
+void suspendProcess(QAtomicInt *pid)
+{
+#ifdef Q_OS_UNIX
+    const int p = pid ? pid->loadRelaxed() : 0;
+    if (p > 0)
+        ::kill(static_cast<pid_t>(p), SIGSTOP);
+#endif
+}
+
+void resumeProcess(QAtomicInt *pid)
+{
+#ifdef Q_OS_UNIX
+    const int p = pid ? pid->loadRelaxed() : 0;
+    if (p > 0)
+        ::kill(static_cast<pid_t>(p), SIGCONT);
+#endif
+}
+
+void killProcess(QAtomicInt *pid)
+{
+#ifdef Q_OS_UNIX
+    const int p = pid ? pid->loadRelaxed() : 0;
+    if (p > 0)
+        ::kill(static_cast<pid_t>(p), SIGKILL);
+#endif
 }
 
 // Locate a .desktop file from its desktop ID ("mpv.desktop"). Under Flatpak
@@ -738,13 +789,28 @@ ArchiveKind archiveKindForPath(const QString &path)
     return ArchiveKind::None;
 }
 
+// "Password" handed to unzip/7z when none is known yet. It is deliberately
+// wrong, and long enough that no real password collides with it; it keeps the
+// tools from prompting on stdin, so the app never blocks waiting for input
+// nobody will type. Encrypted archives just fail fast instead.
+const QLatin1String archivePasswordSentinel("__hyprfm_placeholder_password__");
+
+QString effectiveArchivePassword(const QString &password)
+{
+    return password.isEmpty() ? archivePasswordSentinel : password;
+}
+
 bool archiveExtractCommand(const QString &archivePath, const QString &destination,
+                           const QString &password,
                            QString *program, QStringList *args)
 {
+    const QString pass = effectiveArchivePassword(password);
+
     switch (archiveKindForPath(archivePath)) {
     case ArchiveKind::Zip:
         *program = QStringLiteral("unzip");
-        *args = {QStringLiteral("-o"), archivePath, QStringLiteral("-d"), destination};
+        *args = {QStringLiteral("-o"), QStringLiteral("-P"), pass, archivePath,
+                 QStringLiteral("-d"), destination};
         return true;
     case ArchiveKind::TarGz:
         *program = QStringLiteral("tar");
@@ -779,10 +845,13 @@ bool archiveExtractCommand(const QString &archivePath, const QString &destinatio
         if (!QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty()) {
             *program = QStringLiteral("7z");
             *args = {QStringLiteral("x"), QStringLiteral("-aoa"),
+                     QStringLiteral("-p%1").arg(pass),
                      QStringLiteral("-o%1").arg(destination), archivePath};
             return true;
         }
         if (!QStandardPaths::findExecutable(QStringLiteral("bsdtar")).isEmpty()) {
+            // bsdtar cannot decrypt; it stays as a last resort so unencrypted
+            // archives still extract when 7z is not installed.
             *program = QStringLiteral("bsdtar");
             *args = {QStringLiteral("-xf"), archivePath, QStringLiteral("-C"), destination};
             return true;
@@ -795,8 +864,11 @@ bool archiveExtractCommand(const QString &archivePath, const QString &destinatio
     return false;
 }
 
-bool archiveListCommand(const QString &archivePath, QString *program, QStringList *args)
+bool archiveListCommand(const QString &archivePath, const QString &password,
+                        QString *program, QStringList *args)
 {
+    const QString pass = effectiveArchivePassword(password);
+
     switch (archiveKindForPath(archivePath)) {
     case ArchiveKind::Zip:
         *program = QStringLiteral("unzip");
@@ -820,14 +892,17 @@ bool archiveListCommand(const QString &archivePath, QString *program, QStringLis
         return true;
     case ArchiveKind::SevenZip:
     case ArchiveKind::Rar:
+        // bsdtar takes no password, so the pass-aware list always goes
+        // through 7z; only the password-less fallback may use bsdtar.
+        if (!QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty()) {
+            *program = QStringLiteral("7z");
+            *args = {QStringLiteral("l"), QStringLiteral("-ba"), QStringLiteral("-slt"),
+                     QStringLiteral("-p%1").arg(pass), archivePath};
+            return true;
+        }
         if (!QStandardPaths::findExecutable(QStringLiteral("bsdtar")).isEmpty()) {
             *program = QStringLiteral("bsdtar");
             *args = {QStringLiteral("-tf"), archivePath};
-            return true;
-        }
-        if (!QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty()) {
-            *program = QStringLiteral("7z");
-            *args = {QStringLiteral("l"), QStringLiteral("-ba"), QStringLiteral("-slt"), archivePath};
             return true;
         }
         return false;
@@ -2002,8 +2077,12 @@ int FileOperations::compressFiles(const QStringList &paths, const QString &forma
     }
 
     const QString statusText = QString("Compressing %1 item(s)...").arg(paths.size());
+    auto processId = QSharedPointer<QAtomicInt>::create();
+    auto cancelled = QSharedPointer<QAtomicInt>::create();
+    auto pauseRequested = QSharedPointer<QAtomicInt>::create();
     return startSimpleOperation(statusText, {outputPath},
-        [paths, parentDir, program, args](ProgressReporter report) -> QString {
+        [paths, parentDir, program, args, processId, cancelled, pauseRequested]
+        (ProgressReporter report) -> QString {
             // Pre-count files for progress
             int totalFiles = 0;
             for (const auto &p : paths) {
@@ -2021,38 +2100,55 @@ int FileOperations::compressFiles(const QStringList &paths, const QString &forma
             report(0, totalFiles, {});
 
             // Run with verbose output and count lines for progress
-            QProcess proc;
-            proc.setWorkingDirectory(parentDir);
-            proc.setProcessChannelMode(QProcess::MergedChannels);
-            proc.start(program, args);
-            if (!proc.waitForStarted(5000))
+            QProcess pr;
+            pr.setWorkingDirectory(parentDir);
+            pr.setProcessChannelMode(QProcess::MergedChannels);
+            pr.start(program, args);
+            if (!pr.waitForStarted(5000))
                 return QStringLiteral("Failed to start compression");
+            processId->storeRelaxed(static_cast<int>(pr.processId()));
+            if (pauseRequested->loadRelaxed())
+                suspendProcess(processId.data());
 
             int processed = 0;
-            while (proc.state() != QProcess::NotRunning || proc.canReadLine()) {
-                if (!proc.canReadLine())
-                    proc.waitForReadyRead(200);
-                while (proc.canReadLine()) {
-                    const QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                    if (line.isEmpty()) continue;
-                    ++processed;
-                    const QString fileName = line.mid(line.lastIndexOf('/') + 1);
+            while (pr.state() != QProcess::NotRunning || pr.bytesAvailable()) {
+                if (cancelled->loadRelaxed())
+                    break;
+                if (!pr.bytesAvailable())
+                    pr.waitForReadyRead(200);
+                const QByteArray chunk = pr.read(65536);
+                if (chunk.isEmpty())
+                    continue;
+                const int newlines = static_cast<int>(chunk.count('\n'));
+                if (newlines > 0) {
+                    processed += newlines;
+                    const QString tail = QString::fromUtf8(chunk);
+                    const QString fileName =
+                        tail.mid(tail.lastIndexOf(QLatin1Char('\n')) + 1).trimmed();
                     report(qMin(processed, totalFiles), totalFiles, fileName);
                 }
             }
 
-            proc.waitForFinished(5000);
-            if (proc.exitCode() != 0)
+            if (cancelled->loadRelaxed() && pr.state() != QProcess::NotRunning)
+                pr.kill();
+            pr.waitForFinished(5000);
+            if (pr.exitCode() != 0)
                 return QStringLiteral("Compression failed");
             return {};
-        });
+        }, processId, cancelled, pauseRequested);
 }
 
 int FileOperations::extractArchive(const QString &archivePath, const QString &destination)
 {
+    return extractArchive(archivePath, destination, QString());
+}
+
+int FileOperations::extractArchive(const QString &archivePath, const QString &destination,
+                                   const QString &password)
+{
     QString program;
     QStringList args;
-    if (!archiveExtractCommand(archivePath, destination, &program, &args))
+    if (!archiveExtractCommand(archivePath, destination, password, &program, &args))
         return -1;
 
     // Add verbose flag for progress tracking
@@ -2061,52 +2157,116 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
         verboseArgs.prepend(QStringLiteral("-v"));
     else if (program == "unzip")
         { /* unzip is already verbose by default */ }
-    // 7z, gunzip, unxz, bunzip2 — no easy verbose line-per-file
 
     // Pre-count files in archive for progress
     QString listProg;
     QStringList listArgs;
-    const bool canList = archiveListCommand(archivePath, &listProg, &listArgs);
+    const bool canList = archiveListCommand(archivePath, password, &listProg, &listArgs);
 
+    // 7z prints no per-file lines while extracting, so track its progress by
+    // comparing the archive's total uncompressed size against the bytes that
+    // have landed in the destination folder.
+    const bool byteBased = (program == "7z");
+    static const QRegularExpression sizeLineRegex(QStringLiteral("^Size = (\\d+)$"),
+                                                  QRegularExpression::MultilineOption);
+    auto processId = QSharedPointer<QAtomicInt>::create();
+    auto cancelled = QSharedPointer<QAtomicInt>::create();
+    auto pauseRequested = QSharedPointer<QAtomicInt>::create();
     return startSimpleOperation(QStringLiteral("Extracting..."), {destination},
-        [program, verboseArgs, canList, listProg, listArgs](ProgressReporter report) -> QString {
-            int totalFiles = 0;
+        [program, verboseArgs, canList, listProg, listArgs, archivePath, destination,
+         processId, cancelled, pauseRequested, byteBased, this](ProgressReporter report) -> QString {
+            QProcess pr;
+            qint64 totalUnits = 0;
             if (canList) {
-                QProcess listProc;
-                listProc.start(listProg, listArgs);
-                if (listProc.waitForFinished(30000) && listProc.exitCode() == 0) {
-                    const QByteArray output = listProc.readAllStandardOutput();
-                    totalFiles = output.count('\n');
+                pr.start(listProg, listArgs);
+                if (pr.waitForFinished(30000) && pr.exitCode() == 0) {
+                    const QString output = QString::fromUtf8(pr.readAllStandardOutput());
+                    if (byteBased) {
+                        QRegularExpressionMatchIterator it =
+                            sizeLineRegex.globalMatch(output);
+                        while (it.hasNext())
+                            totalUnits += it.next().captured(1).toLongLong();
+                    } else {
+                        totalUnits = output.count(QLatin1Char('\n'));
+                    }
                 }
             }
-            if (totalFiles <= 0) totalFiles = 1;
-
-            report(0, totalFiles, {});
-
-            QProcess proc;
-            proc.setProcessChannelMode(QProcess::MergedChannels);
-            proc.start(program, verboseArgs);
-            if (!proc.waitForStarted(5000))
-                return QStringLiteral("Failed to start extraction");
-
-            int processed = 0;
-            while (proc.state() != QProcess::NotRunning || proc.canReadLine()) {
-                if (!proc.canReadLine())
-                    proc.waitForReadyRead(200);
-                while (proc.canReadLine()) {
-                    const QString line = QString::fromUtf8(proc.readLine()).trimmed();
-                    if (line.isEmpty()) continue;
-                    ++processed;
-                    const QString fileName = line.mid(line.lastIndexOf('/') + 1);
-                    report(qMin(processed, totalFiles), totalFiles, fileName);
-                }
-            }
-
-            proc.waitForFinished(5000);
-            if (proc.exitCode() != 0)
+            if (cancelled->loadRelaxed())
                 return QStringLiteral("Extraction failed");
+            if (totalUnits <= 0) totalUnits = 1;
+
+            // Scale byte counters down so the (int, int) reporter never
+            // overflows even for very large archives.
+            const qint64 reportTotal = byteBased
+                ? qMax<qint64>(totalUnits >> 16, 1) : totalUnits;
+            report(0, static_cast<int>(reportTotal), {});
+
+            pr.setProcessChannelMode(QProcess::MergedChannels);
+            pr.start(program, verboseArgs);
+            if (!pr.waitForStarted(5000))
+                return QStringLiteral("Failed to start extraction");
+            processId->storeRelaxed(static_cast<int>(pr.processId()));
+            if (pauseRequested->loadRelaxed())
+                suspendProcess(processId.data());
+
+            QList<QByteArray> outputLines;
+            qint64 processed = 0;
+            QElapsedTimer sizeScanTimer;
+            sizeScanTimer.start();
+            while (pr.state() != QProcess::NotRunning || pr.bytesAvailable()) {
+                if (cancelled->loadRelaxed())
+                    break;
+                if (!pr.bytesAvailable())
+                    pr.waitForReadyRead(200);
+                QByteArray chunk;
+                if (pr.bytesAvailable()) {
+                    chunk = pr.read(65536);
+                    outputLines.append(chunk);
+                }
+                if (byteBased) {
+                    if (sizeScanTimer.elapsed() >= 250) {
+                        sizeScanTimer.restart();
+                        const qint64 extracted = dirTotalBytes(destination);
+                        processed = qMax(processed, extracted);
+                        report(static_cast<int>(processed >> 16),
+                               static_cast<int>(reportTotal), {});
+                    }
+                } else if (!chunk.isEmpty()) {
+                    const int newlines = static_cast<int>(chunk.count('\n'));
+                    if (newlines > 0) {
+                        processed += newlines;
+                        const QString tail = QString::fromUtf8(chunk);
+                        const QString fileName =
+                            tail.mid(tail.lastIndexOf(QLatin1Char('\n')) + 1).trimmed();
+                        report(qMin(processed, reportTotal), static_cast<int>(reportTotal),
+                               fileName);
+                    }
+                }
+            }
+
+            if (cancelled->loadRelaxed() && pr.state() != QProcess::NotRunning)
+                pr.kill();
+            pr.waitForFinished(5000);
+            if (pr.exitCode() != 0) {
+                QString output;
+                for (const QByteArray &line : outputLines)
+                    output += QString::fromLatin1(line) + QLatin1Char('\n');
+                if (output.contains(QLatin1String("password"), Qt::CaseInsensitive)
+                    || output.contains(QLatin1String("passphrase"), Qt::CaseInsensitive)) {
+                    // Encrypted archive rejected the password; drop any cached
+                    // value and ask the UI, which retries with what it gets.
+                    const QString archive = archivePath;
+                    const QString dest = destination;
+                    QMetaObject::invokeMethod(this, [this, archive, dest]() {
+                        clearArchivePassword(archive);
+                        emit passwordRequested(archive, dest);
+                    }, Qt::QueuedConnection);
+                    return QStringLiteral("password required");
+                }
+                return QStringLiteral("Extraction failed");
+            }
             return {};
-        });
+        }, processId, cancelled, pauseRequested);
 }
 
 // Opening an archive extracts it into a fresh folder next to it. Extracting
@@ -2147,7 +2307,7 @@ QString FileOperations::archiveRootFolder(const QString &archivePath)
 {
     QString program;
     QStringList args;
-    if (!archiveListCommand(archivePath, &program, &args))
+    if (!archiveListCommand(archivePath, QString(), &program, &args))
         return {};
 
     QProcess proc;
@@ -2163,6 +2323,21 @@ QString FileOperations::archiveRootFolder(const QString &archivePath)
     return commonArchiveRootFolder(entries);
 }
 
+QString FileOperations::archivePassword(const QString &archivePath) const
+{
+    return m_archivePasswords.value(archivePath);
+}
+
+void FileOperations::cacheArchivePassword(const QString &archivePath, const QString &password)
+{
+    m_archivePasswords.insert(archivePath, password);
+}
+
+void FileOperations::clearArchivePassword(const QString &archivePath)
+{
+    m_archivePasswords.remove(archivePath);
+}
+
 bool FileOperations::isArchive(const QString &path)
 {
     return archiveKindForPath(path) != ArchiveKind::None;
@@ -2170,41 +2345,61 @@ bool FileOperations::isArchive(const QString &path)
 
 void FileOperations::pauseTransfer(int transferId)
 {
-    if (transferId < 0) {
-        for (auto &t : m_activeTransfers) {
+    auto pauseOne = [](ActiveTransfer &t) {
+        if (t.worker)
             t.worker->pause();
-            t.paused = true;
-            t.statusText = QStringLiteral("Paused");
-        }
+        else
+            suspendProcess(t.processId.data());
+        if (t.pauseRequested)
+            t.pauseRequested->storeRelaxed(1);
+        t.paused = true;
+        t.statusText = QStringLiteral("Paused");
+    };
+    if (transferId < 0) {
+        for (auto &t : m_activeTransfers)
+            pauseOne(t);
     } else if (auto *t = findTransfer(transferId)) {
-        t->worker->pause();
-        t->paused = true;
-        t->statusText = QStringLiteral("Paused");
+        pauseOne(*t);
     }
     emitAggregatedState();
 }
 
 void FileOperations::resumeTransfer(int transferId)
 {
-    if (transferId < 0) {
-        for (auto &t : m_activeTransfers) {
+    auto resumeOne = [](ActiveTransfer &t) {
+        if (t.worker)
             t.worker->resume();
-            t.paused = false;
-        }
+        else
+            resumeProcess(t.processId.data());
+        if (t.pauseRequested)
+            t.pauseRequested->storeRelaxed(0);
+        t.paused = false;
+    };
+    if (transferId < 0) {
+        for (auto &t : m_activeTransfers)
+            resumeOne(t);
     } else if (auto *t = findTransfer(transferId)) {
-        t->worker->resume();
-        t->paused = false;
+        resumeOne(*t);
     }
     emitAggregatedState();
 }
 
 void FileOperations::cancelTransfer(int transferId)
 {
+    auto cancelOne = [](ActiveTransfer &t) {
+        if (t.worker)
+            t.worker->cancel();
+        else {
+            if (t.cancelled)
+                t.cancelled->storeRelaxed(1);
+            killProcess(t.processId.data());
+        }
+    };
     if (transferId < 0) {
         for (auto &t : m_activeTransfers)
-            t.worker->cancel();
+            cancelOne(t);
     } else if (auto *t = findTransfer(transferId)) {
-        t->worker->cancel();
+        cancelOne(*t);
     }
 }
 
@@ -2226,7 +2421,10 @@ void FileOperations::cleanupTransfer(int transferId)
 }
 
 int FileOperations::startSimpleOperation(const QString &statusText, const QStringList &changedPaths,
-                                           std::function<QString(ProgressReporter)> work)
+                                           std::function<QString(ProgressReporter)> work,
+                                           const QSharedPointer<QAtomicInt> &processId,
+                                           const QSharedPointer<QAtomicInt> &cancelled,
+                                           const QSharedPointer<QAtomicInt> &pauseRequested)
 {
     const int id = m_nextTransferId++;
     ActiveTransfer transfer;
@@ -2234,6 +2432,9 @@ int FileOperations::startSimpleOperation(const QString &statusText, const QStrin
     transfer.statusText = statusText;
     transfer.progress = -1.0;
     transfer.changedPaths = changedPaths;
+    transfer.processId = processId;
+    transfer.cancelled = cancelled;
+    transfer.pauseRequested = pauseRequested;
 
     auto *thread = new QThread;
     transfer.thread = thread;

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -2285,6 +2285,15 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
                 }
                 return QStringLiteral("Extraction failed");
             }
+            // The archive is done with; the password goes with it. Held only
+            // for as long as it is being used, the way Ark and File Roller
+            // scope it to the archive you currently have open.
+            {
+                const QString archive = archivePath;
+                QMetaObject::invokeMethod(this, [this, archive]() {
+                    clearArchivePassword(archive);
+                }, Qt::QueuedConnection);
+            }
             return {};
         }, processId, cancelled, pauseRequested);
 }

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -1,4 +1,5 @@
 #include "services/fileoperations.h"
+#include "services/archivepassword.h"
 #include "services/giotransferworker.h"
 #include "services/xdgtrash.h"
 #include <QBuffer>
@@ -787,17 +788,6 @@ ArchiveKind archiveKindForPath(const QString &path)
     if (lower.endsWith(QStringLiteral(".bz2")))
         return ArchiveKind::Bz2;
     return ArchiveKind::None;
-}
-
-// "Password" handed to unzip/7z when none is known yet. It is deliberately
-// wrong, and long enough that no real password collides with it; it keeps the
-// tools from prompting on stdin, so the app never blocks waiting for input
-// nobody will type. Encrypted archives just fail fast instead.
-const QLatin1String archivePasswordSentinel("__hyprfm_placeholder_password__");
-
-QString effectiveArchivePassword(const QString &password)
-{
-    return password.isEmpty() ? archivePasswordSentinel : password;
 }
 
 bool archiveExtractCommand(const QString &archivePath, const QString &destination,
@@ -2132,6 +2122,10 @@ int FileOperations::compressFiles(const QStringList &paths, const QString &forma
             if (cancelled->loadRelaxed() && pr.state() != QProcess::NotRunning)
                 pr.kill();
             pr.waitForFinished(5000);
+            // Forget the pid the moment the process is gone: cancelTransfer(-1)
+            // walks every transfer, including ones whose subprocess has exited
+            // but whose cleanup has not run, and the OS recycles pids.
+            processId->storeRelaxed(0);
             if (pr.exitCode() != 0)
                 return QStringLiteral("Compression failed");
             return {};
@@ -2247,6 +2241,10 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
             if (cancelled->loadRelaxed() && pr.state() != QProcess::NotRunning)
                 pr.kill();
             pr.waitForFinished(5000);
+            // Forget the pid the moment the process is gone: cancelTransfer(-1)
+            // walks every transfer, including ones whose subprocess has exited
+            // but whose cleanup has not run, and the OS recycles pids.
+            processId->storeRelaxed(0);
             if (pr.exitCode() != 0) {
                 QString output;
                 for (const QByteArray &line : outputLines)
@@ -2258,8 +2256,11 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
                     const QString archive = archivePath;
                     const QString dest = destination;
                     QMetaObject::invokeMethod(this, [this, archive, dest]() {
+                        // Read before clearing: a password that was already
+                        // set and still failed is a wrong one, not a first ask.
+                        const bool retry = !archivePassword(archive).isEmpty();
                         clearArchivePassword(archive);
-                        emit passwordRequested(archive, dest);
+                        emit passwordRequested(archive, dest, retry);
                     }, Qt::QueuedConnection);
                     return QStringLiteral("password required");
                 }

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -2175,8 +2175,11 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
     auto cancelled = QSharedPointer<QAtomicInt>::create();
     auto pauseRequested = QSharedPointer<QAtomicInt>::create();
     // Only a folder we made for this archive is ours to clean up on failure;
-    // "Extract Here" unpacks into a directory that was already there.
-    const bool destinationIsOurs = m_ownedExtractionDirs.remove(destination);
+    // "Extract Here" unpacks into a directory that was already there. Kept in
+    // the set rather than consumed: a wrong password retries into the same
+    // destination, and taking the entry on the first attempt would leave every
+    // later refusal behind.
+    const bool destinationIsOurs = m_ownedExtractionDirs.contains(destination);
     return startSimpleOperation(QStringLiteral("Extracting..."), {destination},
         [program, verboseArgs, canList, listProg, listArgs, archivePath, destination,
          processId, cancelled, pauseRequested, byteBased, destinationIsOurs,

--- a/src/services/fileoperations.cpp
+++ b/src/services/fileoperations.cpp
@@ -44,6 +44,14 @@ bool runningInFlatpak()
 // Total size of all regular files under a directory, used to turn raw
 // extraction output into smooth byte-based progress (7z prints no per-file
 // lines, only an in-place percentage that stalls near the end).
+// Whether anything actually landed. A refused extraction can still leave the
+// directory entries the tool created before it gave up.
+bool dirHasFiles(const QString &dir)
+{
+    QDirIterator it(dir, QDir::Files | QDir::Hidden, QDirIterator::Subdirectories);
+    return it.hasNext();
+}
+
 qint64 dirTotalBytes(const QString &dir)
 {
     qint64 total = 0;
@@ -2166,9 +2174,13 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
     auto processId = QSharedPointer<QAtomicInt>::create();
     auto cancelled = QSharedPointer<QAtomicInt>::create();
     auto pauseRequested = QSharedPointer<QAtomicInt>::create();
+    // Only a folder we made for this archive is ours to clean up on failure;
+    // "Extract Here" unpacks into a directory that was already there.
+    const bool destinationIsOurs = m_ownedExtractionDirs.remove(destination);
     return startSimpleOperation(QStringLiteral("Extracting..."), {destination},
         [program, verboseArgs, canList, listProg, listArgs, archivePath, destination,
-         processId, cancelled, pauseRequested, byteBased, this](ProgressReporter report) -> QString {
+         processId, cancelled, pauseRequested, byteBased, destinationIsOurs,
+         this](ProgressReporter report) -> QString {
             QProcess pr;
             qint64 totalUnits = 0;
             if (canList) {
@@ -2249,6 +2261,10 @@ int FileOperations::extractArchive(const QString &archivePath, const QString &de
                 QString output;
                 for (const QByteArray &line : outputLines)
                     output += QString::fromLatin1(line) + QLatin1Char('\n');
+                // Nothing landed, and the folder only exists because we made
+                // it: leave no empty husk next to the archive.
+                if (destinationIsOurs && !dirHasFiles(destination))
+                    QDir(destination).removeRecursively();
                 if (output.contains(QLatin1String("password"), Qt::CaseInsensitive)
                     || output.contains(QLatin1String("passphrase"), Qt::CaseInsensitive)) {
                     // Encrypted archive rejected the password; drop any cached
@@ -2301,6 +2317,7 @@ QString FileOperations::newExtractionFolder(const QString &archivePath)
             ? QStringLiteral("Could not create a folder to extract into") : error);
         return {};
     }
+    m_ownedExtractionDirs.insert(dir);
     return dir;
 }
 

--- a/src/services/fileoperations.h
+++ b/src/services/fileoperations.h
@@ -154,6 +154,11 @@ private:
 
     // path -> password, kept for this session only.
     QHash<QString, QString> m_archivePasswords;
+
+    // Folders newExtractionFolder() made. Only these are ours to remove when
+    // an extraction fails without unpacking anything: "Extract Here" targets a
+    // directory the user already had.
+    QSet<QString> m_ownedExtractionDirs;
     void emitAggregatedState();
     ActiveTransfer *findTransfer(int id);
 

--- a/src/services/fileoperations.h
+++ b/src/services/fileoperations.h
@@ -104,7 +104,10 @@ signals:
     void pathsChanged(const QStringList &paths);
     // An encrypted archive rejected the current password; the UI should ask
     // the user and retry extractArchive() with the password it gets.
-    void passwordRequested(const QString &archivePath, const QString &destination);
+    // `retry` is true when a password had already been supplied and was
+    // wrong, so the dialog can say so instead of reopening unchanged.
+    void passwordRequested(const QString &archivePath, const QString &destination,
+                           bool retry);
     // operationId matches the value returned by the operation that started
     // it (-1 for synchronous failures), so callers waiting on one operation
     // are not satisfied by another one finishing first.

--- a/src/services/fileoperations.h
+++ b/src/services/fileoperations.h
@@ -3,6 +3,9 @@
 #include <QObject>
 #include <QProcess>
 #include <QByteArray>
+#include <QHash>
+#include <QAtomicInteger>
+#include <QSharedPointer>
 #include <QStringList>
 #include <QVariantList>
 #include <QVariantMap>
@@ -76,6 +79,12 @@ public:
     Q_INVOKABLE void openNewWindow(const QString &dirPath);
     Q_INVOKABLE int compressFiles(const QStringList &paths, const QString &format);
     Q_INVOKABLE int extractArchive(const QString &archivePath, const QString &destination);
+    Q_INVOKABLE int extractArchive(const QString &archivePath, const QString &destination,
+                                   const QString &password);
+    // Session-only, in-memory password cache for archives. Never persisted.
+    Q_INVOKABLE QString archivePassword(const QString &archivePath) const;
+    Q_INVOKABLE void cacheArchivePassword(const QString &archivePath, const QString &password);
+    Q_INVOKABLE void clearArchivePassword(const QString &archivePath);
     Q_INVOKABLE QString newExtractionFolder(const QString &archivePath);
     Q_INVOKABLE static bool isArchive(const QString &path);
     Q_INVOKABLE QString archiveRootFolder(const QString &archivePath);
@@ -93,6 +102,9 @@ signals:
     void currentFileChanged();
     void activeTransfersChanged();
     void pathsChanged(const QStringList &paths);
+    // An encrypted archive rejected the current password; the UI should ask
+    // the user and retry extractArchive() with the password it gets.
+    void passwordRequested(const QString &archivePath, const QString &destination);
     // operationId matches the value returned by the operation that started
     // it (-1 for synchronous failures), so callers waiting on one operation
     // are not satisfied by another one finishing first.
@@ -103,6 +115,12 @@ private:
         int id = 0;
         QThread *thread = nullptr;
         GioTransferWorker *worker = nullptr;
+        // Shared state for simple (external subprocess) operations: atomics
+        // read/written by the GUI and worker threads without touching each
+        // other's QObject instances.
+        QSharedPointer<QAtomicInt> processId;
+        QSharedPointer<QAtomicInt> cancelled;
+        QSharedPointer<QAtomicInt> pauseRequested;
         QString statusText;
         double progress = -1.0;
         QString speed;
@@ -125,8 +143,14 @@ private:
     int startGioTransfer(const QVariantList &operations, bool moveOperation);
     using ProgressReporter = std::function<void(int current, int total, const QString &fileName)>;
     int startSimpleOperation(const QString &statusText, const QStringList &changedPaths,
-                              std::function<QString(ProgressReporter)> work);
+                              std::function<QString(ProgressReporter)> work,
+                              const QSharedPointer<QAtomicInt> &processId = {},
+                              const QSharedPointer<QAtomicInt> &cancelled = {},
+                              const QSharedPointer<QAtomicInt> &pauseRequested = {});
     void cleanupTransfer(int transferId);
+
+    // path -> password, kept for this session only.
+    QHash<QString, QString> m_archivePasswords;
     void emitAggregatedState();
     ActiveTransfer *findTransfer(int id);
 

--- a/src/services/fileoperations.h
+++ b/src/services/fileoperations.h
@@ -81,7 +81,9 @@ public:
     Q_INVOKABLE int extractArchive(const QString &archivePath, const QString &destination);
     Q_INVOKABLE int extractArchive(const QString &archivePath, const QString &destination,
                                    const QString &password);
-    // Session-only, in-memory password cache for archives. Never persisted.
+    // In-memory only, never persisted, and held only while the archive is in
+    // use: an extraction clears it when it finishes, and the preview clears it
+    // when it moves off the file. Same scope Ark and File Roller use.
     Q_INVOKABLE QString archivePassword(const QString &archivePath) const;
     Q_INVOKABLE void cacheArchivePassword(const QString &archivePath, const QString &password);
     Q_INVOKABLE void clearArchivePassword(const QString &archivePath);
@@ -152,7 +154,7 @@ private:
                               const QSharedPointer<QAtomicInt> &pauseRequested = {});
     void cleanupTransfer(int transferId);
 
-    // path -> password, kept for this session only.
+    // path -> password, for as long as that archive is in use.
     QHash<QString, QString> m_archivePasswords;
 
     // Folders newExtractionFolder() made. Only these are ours to remove when

--- a/src/services/previewservice.cpp
+++ b/src/services/previewservice.cpp
@@ -468,7 +468,8 @@ QVariantMap PreviewService::loadDirectoryPreview(const QString &path, int maxEnt
     return result;
 }
 
-QVariantMap PreviewService::loadArchivePreview(const QString &path, int maxEntries) const
+QVariantMap PreviewService::loadArchivePreview(const QString &path, int maxEntries,
+                                               const QString &password) const
 {
     QVariantMap result;
     result["entries"] = QStringList();
@@ -497,9 +498,15 @@ QVariantMap PreviewService::loadArchivePreview(const QString &path, int maxEntri
     } else if (lower.endsWith(".tar")) {
         program = "tar";
         args = {"-tf", path};
-    } else if (lower.endsWith(".7z") || lower.endsWith(".rar")) {
+} else if (lower.endsWith(".7z") || lower.endsWith(".rar")) {
+        // Always pass -p so 7z never waits for interactive input: an archive
+        // without a password ignores it, an encrypted one fails immediately.
+        // The sentinel (kept in sync with fileoperations.cpp) is long enough
+        // that no real password collides with it.
         program = "7z";
-        args = {"l", "-slt", path};
+        const QString pass = password.isEmpty()
+            ? QLatin1String("__hyprfm_placeholder_password__") : password;
+        args = {"l", "-slt", "-p" + pass, path};
     } else {
         result["error"] = "Unsupported archive format";
         return result;
@@ -507,8 +514,21 @@ QVariantMap PreviewService::loadArchivePreview(const QString &path, int maxEntri
 
     QProcess proc;
     proc.start(program, args);
-    if (!proc.waitForFinished(10000) || proc.exitCode() != 0) {
+    if (!proc.waitForFinished(10000)) {
         result["error"] = "Could not list archive contents";
+        return result;
+    }
+
+    if (proc.exitCode() != 0) {
+        const QString errorText = QString::fromUtf8(proc.readAllStandardError());
+        if (errorText.contains(QLatin1String("password"), Qt::CaseInsensitive)
+            || errorText.contains(QLatin1String("passphrase"), Qt::CaseInsensitive)
+            || errorText.contains(QLatin1String("encrypted"), Qt::CaseInsensitive)) {
+            result["requiresPassword"] = true;
+            result["error"] = "This archive is password-protected.";
+        } else {
+            result["error"] = "Could not list archive contents";
+        }
         return result;
     }
 

--- a/src/services/previewservice.cpp
+++ b/src/services/previewservice.cpp
@@ -1,4 +1,5 @@
 #include "services/previewservice.h"
+#include "services/archivepassword.h"
 
 #include "services/metadataextractor.h"
 
@@ -347,7 +348,7 @@ void PreviewService::cancelPreview(const QString &requester)
 }
 
 void PreviewService::requestPreview(const QString &requester, const QString &path,
-                                    const QString &kind)
+                                    const QString &kind, const QString &password)
 {
     const quint64 generation = bumpGeneration(requester);
 
@@ -356,8 +357,8 @@ void PreviewService::requestPreview(const QString &requester, const QString &pat
         return;
     }
 
-    m_pool->start([this, requester, path, kind, generation]() {
-        const QVariantMap data = buildPreview(path, kind);
+    m_pool->start([this, requester, path, kind, password, generation]() {
+        const QVariantMap data = buildPreview(path, kind, password);
 
         // Cheap early-out so a superseded worker doesn't queue a no-op onto
         // the GUI thread. The authoritative check is the one inside the
@@ -373,7 +374,8 @@ void PreviewService::requestPreview(const QString &requester, const QString &pat
     });
 }
 
-QVariantMap PreviewService::buildPreview(const QString &path, const QString &kind) const
+QVariantMap PreviewService::buildPreview(const QString &path, const QString &kind,
+                                         const QString &password) const
 {
     QVariantMap data;
 
@@ -382,7 +384,7 @@ QVariantMap PreviewService::buildPreview(const QString &path, const QString &kin
     else if (kind == QLatin1String("pdf"))
         data["pdf"] = loadPdfPreview(path);
     else if (kind == QLatin1String("archive"))
-        data["archive"] = loadArchivePreview(path);
+        data["archive"] = loadArchivePreview(path, 200, password);
     else if (kind == QLatin1String("directory"))
         data["directory"] = loadDirectoryPreview(path);
 
@@ -501,12 +503,8 @@ QVariantMap PreviewService::loadArchivePreview(const QString &path, int maxEntri
 } else if (lower.endsWith(".7z") || lower.endsWith(".rar")) {
         // Always pass -p so 7z never waits for interactive input: an archive
         // without a password ignores it, an encrypted one fails immediately.
-        // The sentinel (kept in sync with fileoperations.cpp) is long enough
-        // that no real password collides with it.
         program = "7z";
-        const QString pass = password.isEmpty()
-            ? QLatin1String("__hyprfm_placeholder_password__") : password;
-        args = {"l", "-slt", "-p" + pass, path};
+        args = {"l", "-slt", "-p" + effectiveArchivePassword(password), path};
     } else {
         result["error"] = "Unsupported archive format";
         return result;

--- a/src/services/previewservice.h
+++ b/src/services/previewservice.h
@@ -44,7 +44,8 @@ public:
     Q_INVOKABLE QVariantMap loadTextPreview(const QString &path, int maxBytes = 131072,
                                             int maxLines = 400) const;
     Q_INVOKABLE QVariantMap loadDirectoryPreview(const QString &path, int maxEntries = 40) const;
-    Q_INVOKABLE QVariantMap loadArchivePreview(const QString &path, int maxEntries = 200) const;
+    Q_INVOKABLE QVariantMap loadArchivePreview(const QString &path, int maxEntries = 200,
+                                               const QString &password = QString()) const;
     Q_INVOKABLE QVariantMap loadPdfPreview(const QString &path) const;
     Q_INVOKABLE QVariantMap loadFontPreview(const QString &path);
     Q_INVOKABLE QString localPreviewPath(const QString &path) const;

--- a/src/services/previewservice.h
+++ b/src/services/previewservice.h
@@ -35,8 +35,11 @@ public:
     // requester: the quick-preview overlay and the Miller preview column
     // share this one service, and a global counter would let either cancel
     // the other's in-flight work and leave it blank forever.
+    // `password` only applies to encrypted archives; every other kind
+    // ignores it.
     Q_INVOKABLE void requestPreview(const QString &requester, const QString &path,
-                                    const QString &kind);
+                                    const QString &kind,
+                                    const QString &password = QString());
 
     // Invalidates that requester's in-flight work without starting more.
     Q_INVOKABLE void cancelPreview(const QString &requester);
@@ -68,7 +71,8 @@ private:
     // Runs on a worker thread. Excludes font previews on purpose:
     // QFontDatabase is GUI-thread-only, so QML still calls loadFontPreview
     // directly (it is a local file read, not a subprocess).
-    QVariantMap buildPreview(const QString &path, const QString &kind) const;
+    QVariantMap buildPreview(const QString &path, const QString &kind,
+                             const QString &password) const;
 
     QByteArray readPathBytes(const QString &path, qint64 maxBytes, bool *truncated,
                              QString *error) const;

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -4,14 +4,17 @@
 #include <QTemporaryDir>
 #include <QFile>
 #include <QDir>
+#include <QDirIterator>
 #include <QGuiApplication>
 #include <QImage>
 #include <QMimeData>
 #include <QProcess>
+#include <QRandomGenerator>
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QUrl>
 #include <QUuid>
+#include <cstring>
 #include <unistd.h>
 #include "testdir.h"
 #include "services/fileoperations.h"
@@ -64,14 +67,36 @@ class TestFileOperations : public QObject
     }
 
     static bool runCommand(const QString &program, const QStringList &args,
-                           const QString &workingDirectory = {})
+                           const QString &workingDirectory = {}, int timeoutMs = 5000)
     {
         QProcess proc;
         if (!workingDirectory.isEmpty())
             proc.setWorkingDirectory(workingDirectory);
 
         proc.start(program, args);
-        return proc.waitForFinished(5000) && proc.exitCode() == 0;
+        return proc.waitForFinished(timeoutMs) && proc.exitCode() == 0;
+    }
+
+    // One-level archive with enough incompressible data that extraction lasts
+    // long enough to pause or cancel mid-flight. Empty on failure.
+    static QString createWideArchive(TestDir &archiveDir, int fileCount, int perFileBytes)
+    {
+        QRandomGenerator rng(12345);
+        for (int i = 0; i < fileCount; ++i) {
+            QByteArray data(perFileBytes, Qt::Uninitialized);
+            const int fullWords = perFileBytes / 4;
+            for (int j = 0; j < fullWords; ++j) {
+                const quint32 v = rng.generate();
+                memcpy(data.data() + j * 4, &v, 4);
+            }
+            for (int j = fullWords * 4; j < perFileBytes; ++j)
+                data[j] = static_cast<char>(rng.generate() & 0xFF);
+            archiveDir.createFile("payload/f" + QString::number(i) + ".dat", data);
+        }
+        const QString archivePath = archiveDir.path() + "/wide.7z";
+        if (!runCommand("7z", {"a", archivePath, "payload"}, archiveDir.path(), 120000))
+            return {};
+        return archivePath;
     }
 
 private slots:
@@ -1174,6 +1199,126 @@ private slots:
         QVERIFY(spy.wait(5000));
         QCOMPARE(spy.at(0).at(0).toBool(), true);
         QVERIFY(QFile::exists(extractDir.path() + "/payload/inner.txt"));
+    }
+
+    // A password-protected archive must fail fast through the placeholder
+    // password (never block waiting for stdin), report "password required",
+    // and succeed once the real password is handed to the retry.
+    void testExtractPasswordProtectedArchive()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty())
+            QSKIP("7z not found in PATH");
+
+        TestDir archiveDir;
+        TestDir extractDir;
+        archiveDir.createDir("payload");
+        archiveDir.createFile("payload/inner.txt", "secret");
+        const QString archivePath = archiveDir.path() + "/locked_headers.7z";
+        QVERIFY(runCommand("7z",
+            {"a", "-ptest", "-mhe=on", archivePath, "payload"}, archiveDir.path()));
+        QVERIFY(QFile::exists(archivePath));
+
+        FileOperations ops;
+        QSignalSpy finishSpy(&ops, &FileOperations::operationFinished);
+        QSignalSpy passwordSpy(&ops, &FileOperations::passwordRequested);
+
+        ops.extractArchive(archivePath, extractDir.path(), QString());
+
+        QVERIFY(passwordSpy.wait(5000));
+        QCOMPARE(finishSpy.count(), 1);
+        QCOMPARE(finishSpy.at(0).at(0).toBool(), false);
+        QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
+        QVERIFY(!QFile::exists(extractDir.path() + "/payload/inner.txt"));
+
+        finishSpy.clear();
+        ops.extractArchive(archivePath, extractDir.path(), QStringLiteral("test"));
+
+        QVERIFY(finishSpy.wait(5000));
+        QCOMPARE(finishSpy.at(0).at(0).toBool(), true);
+        QVERIFY(QFile::exists(extractDir.path() + "/payload/inner.txt"));
+    }
+
+    // Extracting via an external binary must stop promptly when cancelled;
+    // previously the transfer had no worker and the cancel was a no-op that
+    // let the extraction run to completion.
+    void testCancelStopsExtractionMidFlight()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty())
+            QSKIP("7z not found in PATH");
+
+        TestDir archiveDir;
+        TestDir extractDir;
+        const QString archivePath = createWideArchive(archiveDir, 300, 256 * 1024);
+        QVERIFY2(!archivePath.isEmpty(), "failed to create wide 7z archive");
+
+        FileOperations ops;
+        QSignalSpy finishSpy(&ops, &FileOperations::operationFinished);
+        const int id = ops.extractArchive(archivePath, extractDir.path());
+        QVERIFY(id >= 0);
+
+        QTRY_VERIFY_WITH_TIMEOUT(ops.busy(), 5000);
+        // Cancel once extraction has clearly started (7z created its output
+        // folder but cannot be done yet), so the operation must end early and
+        // report a failure rather than extracting every file.
+        QTRY_VERIFY_WITH_TIMEOUT(
+            QFileInfo(extractDir.path() + QLatin1String("/payload")).exists(), 10000);
+        ops.cancelTransfer(id);
+        QTRY_VERIFY_WITH_TIMEOUT(!ops.busy(), 8000);
+
+        QCOMPARE(finishSpy.count(), 1);
+        QCOMPARE(finishSpy.constFirst().at(0).toBool(), false);
+
+        int landed = 0;
+        bool allValid = true;
+        QDirIterator it(extractDir.path(), QDir::Files, QDirIterator::Subdirectories);
+        while (it.hasNext()) {
+            it.next();
+            // Extracted names must match the archive's own payload/f<index>.dat
+            const QString name = it.fileName();
+            const int dot = name.lastIndexOf(QLatin1Char('.'));
+            bool ok = false;
+            const int index = name.mid(1, dot - 1).toInt(&ok);
+            if (!ok || index < 0 || index >= 300)
+                allValid = false;
+            ++landed;
+        }
+        QVERIFY2(landed < 300, qPrintable(
+            QStringLiteral("cancel did not stop extraction: %1 files").arg(landed)));
+        QVERIFY(allValid);
+    }
+
+    // Pausing an extraction freezes the underlying process, so the byte-based
+    // progress must stop moving until it is resumed.
+    void testPauseFreezesExtractProgress()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty())
+            QSKIP("7z not found in PATH");
+
+        TestDir archiveDir;
+        TestDir extractDir;
+        const QString archivePath = createWideArchive(archiveDir, 300, 256 * 1024);
+        QVERIFY2(!archivePath.isEmpty(), "failed to create wide 7z archive");
+
+        FileOperations ops;
+        QSignalSpy finishSpy(&ops, &FileOperations::operationFinished);
+        const int id = ops.extractArchive(archivePath, extractDir.path());
+        QVERIFY(id >= 0);
+
+        QTRY_VERIFY_WITH_TIMEOUT(ops.busy(), 5000);
+        QTRY_VERIFY(ops.progress() >= 0.0);
+
+        ops.pauseTransfer(id);
+        QVERIFY(ops.paused());
+        const double frozen = ops.progress();
+        QTest::qWait(800);
+        const double later = ops.progress();
+        QVERIFY2(later - frozen < 0.05, qPrintable(
+            QStringLiteral("progress moved while paused: %1 -> %2").arg(frozen).arg(later)));
+        ops.resumeTransfer(id);
+
+        if (finishSpy.isEmpty())
+            QVERIFY(finishSpy.wait(15000));
+        QCOMPARE(finishSpy.constFirst().at(0).toBool(), true);
     }
 
     void testCompressionDoesNotExecuteFileNames_data()

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -1291,6 +1291,35 @@ private slots:
         QVERIFY(QFile::exists(extractDir.path() + "/payload/inner.txt"));
     }
 
+    // A refused extraction used to leave the destination behind: unzip creates
+    // the directory entries before it discovers it cannot decrypt anything, so
+    // a bare "locked/payload/" tree appeared next to the archive and looked
+    // like the extraction had half worked.
+    void testRefusedExtractionLeavesNoEmptyFolder()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("zip")).isEmpty()
+            || QStandardPaths::findExecutable(QStringLiteral("unzip")).isEmpty())
+            QSKIP("zip/unzip not found in PATH");
+
+        TestDir archiveDir;
+        archiveDir.createDir("payload");
+        archiveDir.createFile("payload/inner.txt", "secret");
+        const QString archivePath = archiveDir.path() + "/locked.zip";
+        QVERIFY(runCommand("zip", {"-q", "-P", "testpass", "-r", archivePath, "payload"},
+                           archiveDir.path()));
+
+        FileOperations ops;
+        const QString dest = ops.newExtractionFolder(archivePath);
+        QVERIFY(!dest.isEmpty());
+        QSignalSpy finishSpy(&ops, &FileOperations::operationFinished);
+
+        ops.extractArchive(archivePath, dest, QString());
+        QTRY_VERIFY_WITH_TIMEOUT(finishSpy.count() > 0, 10000);
+        QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
+        QVERIFY2(!QFileInfo::exists(dest),
+                 qPrintable(QStringLiteral("left behind: %1").arg(dest)));
+    }
+
     // Extracting via an external binary must stop promptly when cancelled;
     // previously the transfer had no worker and the cancel was a no-op that
     // let the extraction run to completion.

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -1330,10 +1330,15 @@ private slots:
 
         // ...and a correct password still extracts into it.
         finishSpy.clear();
+        ops.cacheArchivePassword(archivePath, QStringLiteral("testpass"));
         ops.extractArchive(archivePath, dest, QStringLiteral("testpass"));
         QTRY_VERIFY_WITH_TIMEOUT(finishSpy.count() > 0, 10000);
         QCOMPARE(finishSpy.at(0).at(0).toBool(), true);
         QVERIFY(QFile::exists(dest + "/payload/inner.txt"));
+
+        // The archive is done with, so the password does not outlive it: held
+        // only while in use, the way Ark and File Roller scope it.
+        QTRY_VERIFY(ops.archivePassword(archivePath).isEmpty());
     }
 
     // Extracting via an external binary must stop promptly when cancelled;

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -1318,6 +1318,22 @@ private slots:
         QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
         QVERIFY2(!QFileInfo::exists(dest),
                  qPrintable(QStringLiteral("left behind: %1").arg(dest)));
+
+        // The retry after a wrong password reuses the same destination, so the
+        // cleanup has to survive more than one attempt.
+        finishSpy.clear();
+        ops.extractArchive(archivePath, dest, QStringLiteral("wrongpass"));
+        QTRY_VERIFY_WITH_TIMEOUT(finishSpy.count() > 0, 10000);
+        QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
+        QVERIFY2(!QFileInfo::exists(dest),
+                 qPrintable(QStringLiteral("retry left behind: %1").arg(dest)));
+
+        // ...and a correct password still extracts into it.
+        finishSpy.clear();
+        ops.extractArchive(archivePath, dest, QStringLiteral("testpass"));
+        QTRY_VERIFY_WITH_TIMEOUT(finishSpy.count() > 0, 10000);
+        QCOMPARE(finishSpy.at(0).at(0).toBool(), true);
+        QVERIFY(QFile::exists(dest + "/payload/inner.txt"));
     }
 
     // Extracting via an external binary must stop promptly when cancelled;

--- a/tests/tst_fileoperations.cpp
+++ b/tests/tst_fileoperations.cpp
@@ -1225,13 +1225,66 @@ private slots:
         ops.extractArchive(archivePath, extractDir.path(), QString());
 
         QVERIFY(passwordSpy.wait(5000));
-        QCOMPARE(finishSpy.count(), 1);
+        // Queued from the worker before it returns, so passwordRequested lands
+        // ahead of operationFinished. Wait rather than assume the order.
+        QTRY_COMPARE(finishSpy.count(), 1);
         QCOMPARE(finishSpy.at(0).at(0).toBool(), false);
         QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
         QVERIFY(!QFile::exists(extractDir.path() + "/payload/inner.txt"));
 
         finishSpy.clear();
         ops.extractArchive(archivePath, extractDir.path(), QStringLiteral("test"));
+
+        QVERIFY(finishSpy.wait(5000));
+        QCOMPARE(finishSpy.at(0).at(0).toBool(), true);
+        QVERIFY(QFile::exists(extractDir.path() + "/payload/inner.txt"));
+    }
+
+    // Same contract as the 7z case, through unzip, which is present far more
+    // often than 7z (the runner has it and p7zip is a separate install). Keeps
+    // the password path covered even where the 7z tests skip.
+    void testExtractPasswordProtectedZip()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("zip")).isEmpty()
+            || QStandardPaths::findExecutable(QStringLiteral("unzip")).isEmpty())
+            QSKIP("zip/unzip not found in PATH");
+
+        TestDir archiveDir;
+        TestDir extractDir;
+        archiveDir.createDir("payload");
+        archiveDir.createFile("payload/inner.txt", "secret");
+        const QString archivePath = archiveDir.path() + "/locked.zip";
+        QVERIFY(runCommand("zip", {"-q", "-P", "testpass", "-r", archivePath, "payload"},
+                           archiveDir.path()));
+        QVERIFY(QFile::exists(archivePath));
+
+        FileOperations ops;
+        QSignalSpy finishSpy(&ops, &FileOperations::operationFinished);
+        QSignalSpy passwordSpy(&ops, &FileOperations::passwordRequested);
+
+        ops.extractArchive(archivePath, extractDir.path(), QString());
+
+        QVERIFY(passwordSpy.wait(5000));
+        // First ask: nothing was cached, so this is not a retry.
+        QCOMPARE(passwordSpy.constFirst().at(2).toBool(), false);
+        // passwordRequested is queued from the worker before it returns, so it
+        // lands ahead of operationFinished. Wait rather than assume the order.
+        QTRY_COMPARE(finishSpy.count(), 1);
+        QCOMPARE(finishSpy.at(0).at(1).toString(), QStringLiteral("password required"));
+        QVERIFY(!QFile::exists(extractDir.path() + "/payload/inner.txt"));
+
+        // A wrong password must come back as a retry, so the dialog can say so.
+        ops.cacheArchivePassword(archivePath, QStringLiteral("wrongpass"));
+        passwordSpy.clear();
+        finishSpy.clear();
+        ops.extractArchive(archivePath, extractDir.path(), QStringLiteral("wrongpass"));
+
+        QVERIFY(passwordSpy.wait(5000));
+        QCOMPARE(passwordSpy.constFirst().at(2).toBool(), true);
+        QVERIFY(ops.archivePassword(archivePath).isEmpty());
+
+        finishSpy.clear();
+        ops.extractArchive(archivePath, extractDir.path(), QStringLiteral("testpass"));
 
         QVERIFY(finishSpy.wait(5000));
         QCOMPARE(finishSpy.at(0).at(0).toBool(), true);

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -384,6 +384,36 @@ private slots:
                                     .arg(app.window->height())));
     }
 
+    // Q.Dialog.open() used to leave a close animation running, and that
+    // animation ends by setting visible = false. Reopening during one — the
+    // archive password dialog asking again after the password was rejected —
+    // put the dialog up and then tore it straight back down.
+    void testDialogReopenedWhileClosingStaysUp()
+    {
+        App app;
+        QVERIFY(app.load());
+        QQuickItem *dialog = app.item("archivePasswordDialog");
+        QVERIFY(dialog);
+
+        QVERIFY(QMetaObject::invokeMethod(dialog, "openFor",
+                                          Q_ARG(QVariant, QStringLiteral("/tmp/x.7z")),
+                                          Q_ARG(QVariant, false)));
+        QTRY_VERIFY(dialog->isVisible());
+
+        // Close and reopen immediately, without waiting for the animation.
+        QVERIFY(QMetaObject::invokeMethod(dialog, "close"));
+        QVERIFY(QMetaObject::invokeMethod(dialog, "openFor",
+                                          Q_ARG(QVariant, QStringLiteral("/tmp/x.7z")),
+                                          Q_ARG(QVariant, true)));
+
+        // Long enough for the old close animation to have finished and blanked
+        // the dialog, if it were still running.
+        QTest::qWait(400);
+        QVERIFY2(dialog->isVisible(), "reopening during the close animation lost the dialog");
+        QCOMPARE(dialog->property("errorText").toString(),
+                 QStringLiteral("That password did not work. Try again."));
+    }
+
     void testWheelOverTabStripScrollsTabsInTheFullWindow()
     {
         App app;

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -412,6 +412,54 @@ private slots:
         QTRY_VERIFY(!dialog->isVisible());
     }
 
+    // The whole password flow end to end: activating an encrypted archive
+    // fails, the prompt opens, and the password the user types must extract it
+    // AND dismiss the prompt. The dialog sat on "Checking..." forever when the
+    // success never made it back.
+    void testCorrectPasswordExtractsAndDismissesThePrompt()
+    {
+        if (QStandardPaths::findExecutable(QStringLiteral("7z")).isEmpty())
+            QSKIP("7z not found in PATH");
+
+        App app;
+        QVERIFY(app.load());
+
+        const QString dir = app.home.path();
+        QDir().mkpath(dir + "/payload");
+        QFile f(dir + "/payload/inner.txt");
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write("secret");
+        f.close();
+        QProcess zip;
+        zip.setWorkingDirectory(dir);
+        zip.start("7z", {"a", "-ptest", "-mhe=on", dir + "/locked.7z", "payload"});
+        QVERIFY(zip.waitForFinished(20000));
+        QCOMPARE(zip.exitCode(), 0);
+
+        QQuickItem *dialog = app.item("archivePasswordDialog");
+        QVERIFY(dialog);
+
+        QVERIFY(QMetaObject::invokeMethod(app.window->contentItem()->parent(),
+                                          "handlePaneFileActivated",
+                                          Q_ARG(QVariant, QStringLiteral("primary")),
+                                          Q_ARG(QVariant, dir + "/locked.7z"),
+                                          Q_ARG(QVariant, false)));
+
+        QTRY_VERIFY_WITH_TIMEOUT(dialog->isVisible(), 15000);
+        QVERIFY(QMetaObject::invokeMethod(dialog, "openFor", Q_ARG(QVariant, dir + "/locked.7z")));
+        QTRY_VERIFY(dialog->isVisible());
+        dialog->setProperty("filePath", dir + "/locked.7z");
+
+        // Type the right password and submit, as the user would.
+        QQuickItem *field = app.item("archivePasswordField");
+        QVERIFY2(field, "password field not found");
+        field->setProperty("text", QStringLiteral("test"));
+        QVERIFY(QMetaObject::invokeMethod(dialog, "submit"));
+
+        QTRY_VERIFY_WITH_TIMEOUT(!dialog->isVisible(), 20000);
+        QCOMPARE(dialog->property("checking").toBool(), false);
+    }
+
     void testWheelOverTabStripScrollsTabsInTheFullWindow()
     {
         App app;

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -384,11 +384,10 @@ private slots:
                                     .arg(app.window->height())));
     }
 
-    // Q.Dialog.open() used to leave a close animation running, and that
-    // animation ends by setting visible = false. Reopening during one — the
-    // archive password dialog asking again after the password was rejected —
-    // put the dialog up and then tore it straight back down.
-    void testDialogReopenedWhileClosingStaysUp()
+    // A refused password used to close the prompt and reopen it, which read as
+    // a flicker and threw away what was typed. The dialog now stays up and
+    // reports in place, and only a password that actually worked closes it.
+    void testWrongArchivePasswordKeepsThePromptOpen()
     {
         App app;
         QVERIFY(app.load());
@@ -396,22 +395,21 @@ private slots:
         QVERIFY(dialog);
 
         QVERIFY(QMetaObject::invokeMethod(dialog, "openFor",
-                                          Q_ARG(QVariant, QStringLiteral("/tmp/x.7z")),
-                                          Q_ARG(QVariant, false)));
+                                          Q_ARG(QVariant, QStringLiteral("/tmp/x.7z"))));
         QTRY_VERIFY(dialog->isVisible());
+        QVERIFY(dialog->property("errorText").toString().isEmpty());
 
-        // Close and reopen immediately, without waiting for the animation.
-        QVERIFY(QMetaObject::invokeMethod(dialog, "close"));
-        QVERIFY(QMetaObject::invokeMethod(dialog, "openFor",
-                                          Q_ARG(QVariant, QStringLiteral("/tmp/x.7z")),
-                                          Q_ARG(QVariant, true)));
-
-        // Long enough for the old close animation to have finished and blanked
-        // the dialog, if it were still running.
+        QVERIFY(QMetaObject::invokeMethod(dialog, "failed"));
+        // Long enough that a close animation would have finished and hidden it.
         QTest::qWait(400);
-        QVERIFY2(dialog->isVisible(), "reopening during the close animation lost the dialog");
+        QVERIFY2(dialog->isVisible(), "the prompt closed on a wrong password");
         QCOMPARE(dialog->property("errorText").toString(),
-                 QStringLiteral("That password did not work. Try again."));
+                 QStringLiteral("Wrong password. Try again."));
+        QCOMPARE(dialog->property("checking").toBool(), false);
+
+        // Only success dismisses it.
+        QVERIFY(QMetaObject::invokeMethod(dialog, "succeeded"));
+        QTRY_VERIFY(!dialog->isVisible());
     }
 
     void testWheelOverTabStripScrollsTabsInTheFullWindow()


### PR DESCRIPTION
## Summary

HyprFM currently has zero support for password-protected archives: previewing or
extracting a `.7z`/`.rar` with encrypted headers makes the underlying `7z`/`unzip`
wait for a password on stdin that never arrives, freezing the UI. This PR adds an
"archive password" dialog and threads the password through preview and extraction.

## What changed

- **New `ArchivePasswordDialog`** (`src/qml/components/ArchivePasswordDialog.qml`):
  Quill dialog with a password field, opened from the quick preview ("Enter
  password" button), from Enter-on-archive, and from the right-click *Extract*.
- **Preview** (`previewservice.cpp`): `loadArchivePreview()` now always passes
  `-p` so `7z` never blocks on stdin; an encrypted archive fails immediately and
  is reported as `requiresPassword`, showing the unlock button. Retries with the
  cached password once the dialog confirms it.
- **Extraction** (`fileoperations.cpp`):
  - `extractArchive()` gained a password overload; unzip gets `-P`, 7z gets `-p`.
  - Encrypted archives that reject the password emit `passwordRequested()`, the
    dialog asks again, and the extraction retries.
  - `bsdtar` stays as a last resort for unencrypted archives when 7z is missing,
    since it cannot decrypt.
  - Passwords are cached **in memory per archive** for the session and never
    persisted (see "Known limitations").
- **Progress**: 7z prints no per-file lines (its in-place `%` stalls near 100%),
  so extraction progress is now byte-based: the archive's total uncompressed
  size from `7z l -ba -slt` is compared against bytes landed in the destination.
- **Pause/cancel on simple operations**: external-binary transfers (extract,
  compress) now respect Pause / Cancel. The subprocess pid is published as an
  atomic so the GUI thread can `SIGSTOP`/`SIGCONT`/`SIGKILL` it without touching
  a QObject across threads (the QProcess stays in the worker thread).
- **Tests** (`tests/tst_fileoperations.cpp`):
  - `testExtractPasswordProtectedArchive` (encrypted headers): fails fast with
    "password required", never blocks.
  - `testCancelStopsExtractionMidFlight` and `testPauseFreezesExtractProgress`:
    back up a wide 7z archive (~75 MB) and assert cancel/pause actually take
    effect, guarding against the old no-op path.

## Known limitations

- The password travels in the archives binaries' `argv`, so it is briefly
  visible in `ps` while a command runs. This is the realistic approach for a
  manager that shells out; migrating to in-process libarchive (as Dolphin does)
  is left as future work.
- `tst_fileoperations`'s `testTrashHelpersForHomePath` fails on machines where
  `/home` is a separate volume (pre-existing, environment-dependent).

## Testing

```bash
cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON
cmake --build build --parallel
ctest --test-dir build
```

26/27 ctest targets pass; the single failure is the pre-existing
`testTrashHelpersForHomePath` environment case noted above.
