### PR TITLE
feat: configurable startup directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ list(APPEND hyprfm_qml_module_args
         qml/components/KeyboardShortcutsDialog.qml
         qml/components/MissingDependenciesDialog.qml
         qml/components/SettingsPanel.qml
+        qml/components/FolderPickerDialog.qml
 )
 
 qt_add_qml_module(hyprfm ${hyprfm_qml_module_args})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -433,7 +433,28 @@ int main(int argc, char *argv[])
                 sessionData = doc.object();
         }
     }
-    if (sessionData.contains("tabs"))
+    // Startup directory: "last" keeps the saved session's tabs; anything else
+    // opens Home (or the configured folder, `~` expanded) instead. A path
+    // passed on the command line always wins and is handled further down.
+    QString startupPath;
+    bool overrideStartupDir = false;
+    const QString startupDir = config->startupDir();
+    if (isPrimary && initialOpenPath.isEmpty() && startupDir != QStringLiteral("last")) {
+        const QString home = QDir::homePath();
+        if (startupDir == QStringLiteral("home")) {
+            startupPath = home;
+        } else {
+            QString p = startupDir;
+            if (p.startsWith(QLatin1Char('~')))
+                p.replace(0, 1, home);
+            QFileInfo fi(p);
+            if (fi.isDir())
+                startupPath = fi.absoluteFilePath();
+        }
+        // An invalid or missing folder falls back to the saved session.
+        overrideStartupDir = !startupPath.isEmpty();
+    }
+    if (sessionData.contains("tabs") && !overrideStartupDir)
         tabModel->restoreSession(sessionData.value("tabs").toArray(),
                                  sessionData.value("activeTab").toInt(0));
 
@@ -448,6 +469,13 @@ int main(int argc, char *argv[])
     if (!isPrimary && !initialOpenPath.isEmpty()) {
         if (auto *tab = tabModel->activeTab())
             tab->navigateTo(initialOpenPath);
+    }
+
+    // When configured to start somewhere specific, hop the default tab there
+    // instead of the session's folders (already skipped above).
+    if (overrideStartupDir) {
+        if (auto *tab = tabModel->activeTab())
+            tab->navigateTo(startupPath);
     }
 
     BookmarkModel *bookmarks = new BookmarkModel(&app);
@@ -482,6 +510,11 @@ int main(int argc, char *argv[])
     if (initialSplitViewEnabled)
         splitFsModel->setRootPath(initialSecondaryPath);
     mark("Secondary fsModel populated");
+
+    // Dedicated model for folder pickers (Settings → startup_dir), so the
+    // browsing there never disturbs the tabs' own views.
+    FileSystemModel *pickerFsModel = new FileSystemModel(&app);
+    pickerFsModel->setShowHidden(config->showHidden());
 
     FileSystemModel *millerParentModel = new FileSystemModel(&app);
     millerParentModel->setShowHidden(config->showHidden());
@@ -525,6 +558,7 @@ int main(int argc, char *argv[])
         splitFsModel->setShowHidden(config->showHidden());
         millerParentModel->setShowHidden(config->showHidden());
         millerPreviewModel->setShowHidden(config->showHidden());
+        pickerFsModel->setShowHidden(config->showHidden());
         app.setFont(resolveUiFont(config->fontFamily()));
     });
 
@@ -589,6 +623,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("dragHelper", dragHelper);
     engine.rootContext()->setContextProperty("fsModel", fsModel);
     engine.rootContext()->setContextProperty("splitFsModel", splitFsModel);
+    engine.rootContext()->setContextProperty("pickerFsModel", pickerFsModel);
     engine.rootContext()->setContextProperty("millerParentModel", millerParentModel);
     engine.rootContext()->setContextProperty("millerPreviewModel", millerPreviewModel);
     engine.rootContext()->setContextProperty("devices", devices);

--- a/src/qml/components/FolderPickerDialog.qml
+++ b/src/qml/components/FolderPickerDialog.qml
@@ -1,0 +1,291 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import HyprFM
+import Quill as Q
+
+// Mini file manager: browse a folder tree and confirm a directory.
+// Used by Settings for choices like the startup_dir. Left click highlights a
+// row and "Select this folder" picks it (or the folder being browsed if none
+// is highlighted); double-click (or Enter on a highlighted row) descends into
+// a subfolder. Clicking empty space, or right-clicking anywhere in the list,
+// clears the highlight, like a folder picker on other platforms.
+Q.Dialog {
+    id: root
+    anchors.fill: parent
+    title: "Choose Folder"
+    dialogWidth: 440
+    z: 1100
+    closeOnOverlayPress: false
+
+    // Where the browser starts when opened. Empty = home.
+    property string startingFolder: ""
+    // The folder confirmed by the user (highlighted row, or the current dir).
+    property string chosenFolder: ""
+    property string currentDir: ""
+
+    signal folderPicked(string path)
+
+    onOpened: {
+        var start = root.startingFolder !== "" ? root.startingFolder : pickerFsModel.homePath()
+        root.navigateTo(start)
+        folderList.forceActiveFocus()
+    }
+
+    function navigateTo(path) {
+        folderList.currentIndex = -1
+        currentDir = path
+        pickerFsModel.setRootPath(path)
+    }
+
+    // True when the highlighted row is an actual folder (the list hides files).
+    function highlightIsDir() {
+        if (folderList.currentIndex < 0)
+            return false
+        return pickerFsModel.fileProperties(pickerFsModel.filePath(folderList.currentIndex)).isDir
+    }
+
+    // Type a path and press Enter to jump there: supports ~, absolute paths and
+    // names relative to the folder currently shown. Invalid input keeps the old
+    // directory.
+    function goToPath(path) {
+        var p = path.trim()
+        if (p === "") {
+            pathField.text = root.currentDir
+            return
+        }
+        if (p.charAt(0) === "~")
+            p = pickerFsModel.homePath() + p.slice(1)
+        if (p.charAt(0) !== "/")
+            p = root.currentDir + "/" + p
+        var props = pickerFsModel.fileProperties(p)
+        if (props.isDir) {
+            root.navigateTo(props.path)
+            folderList.forceActiveFocus()
+        } else {
+            pathField.text = root.currentDir
+        }
+    }
+
+    function parentOf(path) {
+        var p = path
+        while (p.length > 1 && p.charAt(p.length - 1) === "/")
+            p = p.slice(0, -1)
+        var idx = p.lastIndexOf("/")
+        return idx <= 0 ? "/" : p.slice(0, idx)
+    }
+
+    function goUp() {
+        root.navigateTo(parentOf(root.currentDir))
+    }
+
+    function goHome() {
+        root.navigateTo(pickerFsModel.homePath())
+    }
+
+    function enterFolder(path) {
+        root.navigateTo(path)
+    }
+
+    function selectCurrent() {
+        var path = root.currentDir
+        if (root.highlightIsDir())
+            path = pickerFsModel.filePath(folderList.currentIndex)
+        root.chosenFolder = path
+        root.folderPicked(path)
+        root.accept()
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.bottomMargin: 4
+        spacing: 8
+
+        // "Up one level" arrow, like the back arrow of file explorers.
+        Rectangle {
+            Layout.preferredWidth: 34
+            Layout.preferredHeight: 34
+            Layout.alignment: Qt.AlignVCenter
+            radius: Q.Theme.radius
+            color: upMouse.containsMouse ? Q.Theme.surface1 : Q.Theme.surface0
+
+            Text {
+                anchors.centerIn: parent
+                text: "\uf062"
+                color: Theme.text
+                font.family: Q.Theme.iconFont
+                font.pixelSize: 14
+            }
+
+            MouseArea {
+                id: upMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.goUp()
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 34
+
+            Q.TextField {
+                id: pathField
+                anchors.fill: parent
+                text: root.currentDir
+                variant: "filled"
+                placeholder: "Type a path and press Enter"
+                onHasActiveFocusChanged: {
+                    if (pathField.hasActiveFocus)
+                        pathField.inputItem.selectAll()
+                }
+                onSubmitted: (text) => root.goToPath(text)
+            }
+
+            // A long path is shown as ".../tail" while the field is idle, so it
+            // never spills out of the box. Focusing the field reveals the full
+            // editable text.
+            Text {
+                visible: !pathField.hasActiveFocus
+                         && pathField.inputItem.contentWidth > pathField.inputItem.width
+                anchors.fill: parent
+                anchors.leftMargin: Theme.spacing
+                anchors.rightMargin: Theme.spacing
+                text: pathField.text
+                color: Theme.subtext
+                font.pixelSize: Q.Theme.fontSize
+                font.family: Q.Theme.fontFamily
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideLeft
+            }
+        }
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 300
+        color: "transparent"
+        clip: true
+
+        // Any click landing outside a row (no highlighted folder) clears the
+        // selection, so "Select this folder" keeps meaning the folder shown
+        // in the path field instead of silently guessing.
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: folderList.currentIndex = -1
+        }
+
+        ListView {
+            id: folderList
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: Math.min(300, contentHeight)
+            clip: true
+            model: pickerFsModel
+            focus: true
+            keyNavigationWraps: true
+
+            Keys.onReturnPressed: enterHighlighted()
+            Keys.onEnterPressed: enterHighlighted()
+            function enterHighlighted() {
+                if (root.highlightIsDir())
+                    root.enterFolder(pickerFsModel.filePath(folderList.currentIndex))
+            }
+
+            delegate: Rectangle {
+                required property int index
+                required property bool isDir
+                required property string fileName
+                required property string fileIconName
+                required property bool isSymlink
+
+                // Files are ignored: the picker only browses into folders.
+                // A hidden row must take no height at all, otherwise it eats
+                // clicks meant for the empty area behind the list.
+                visible: isDir
+                height: isDir ? 34 : 0
+                width: folderList.width
+                radius: Theme.radiusSmall
+                color: mouse.containsMouse
+                    ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.08)
+                    : (ListView.isCurrentItem
+                       ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.12)
+                       : "transparent")
+
+                RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: 8
+                    anchors.rightMargin: 8
+                    spacing: 8
+
+                    Image {
+                        Layout.preferredWidth: 18
+                        Layout.preferredHeight: 18
+                        Layout.alignment: Qt.AlignVCenter
+                        source: "image://icon/" + fileIconName + "?theme=" + config.iconTheme
+                        sourceSize: Qt.size(18, 18)
+                    }
+
+                    Text {
+                        text: fileName + (isSymlink ? " (link)" : "")
+                        color: Theme.text
+                        font.pointSize: Theme.fontNormal
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignVCenter
+                        elide: Text.ElideRight
+                    }
+                }
+
+                MouseArea {
+                    id: mouse
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    onClicked: (event) => {
+                        if (event.button === Qt.RightButton) {
+                            folderList.currentIndex = -1
+                        } else {
+                            folderList.currentIndex = index
+                            folderList.forceActiveFocus()
+                        }
+                    }
+                    onDoubleClicked: (event) => {
+                        if (event.button !== Qt.LeftButton)
+                            return
+                        folderList.currentIndex = index
+                        root.enterFolder(pickerFsModel.filePath(index))
+                    }
+                }
+            }
+
+            ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.topMargin: 10
+        spacing: 8
+
+        Q.Button {
+            text: "Home"
+            variant: "ghost"
+            onClicked: root.goHome()
+        }
+
+        Item { Layout.fillWidth: true }
+
+        Q.Button {
+            text: "Cancel"
+            variant: "ghost"
+            onClicked: root.reject()
+        }
+        Q.Button {
+            text: "Select this folder"
+            variant: "primary"
+            onClicked: root.selectCurrent()
+        }
+    }
+}

--- a/src/qml/components/FolderPickerDialog.qml
+++ b/src/qml/components/FolderPickerDialog.qml
@@ -26,11 +26,13 @@ Q.Dialog {
 
     signal folderPicked(string path)
 
-    onOpened: {
-        var start = root.startingFolder !== "" ? root.startingFolder : pickerFsModel.homePath()
-        root.navigateTo(start)
-        folderList.forceActiveFocus()
-    }
+onOpened: {
+    var start = root.startingFolder !== "" ? root.startingFolder : pickerFsModel.homePath()
+    if (start.charAt(0) === "~")
+        start = pickerFsModel.homePath() + start.slice(1)
+    root.navigateTo(start)
+    folderList.forceActiveFocus()
+}
 
     function navigateTo(path) {
         folderList.currentIndex = -1

--- a/src/qml/components/FolderPickerDialog.qml
+++ b/src/qml/components/FolderPickerDialog.qml
@@ -27,16 +27,19 @@ Q.Dialog {
     signal folderPicked(string path)
 
 onOpened: {
-    var start = root.startingFolder !== "" ? root.startingFolder : pickerFsModel.homePath()
-    if (start.charAt(0) === "~")
-        start = pickerFsModel.homePath() + start.slice(1)
-    root.navigateTo(start)
-    folderList.forceActiveFocus()
-}
+        var start = root.startingFolder !== "" ? root.startingFolder : pickerFsModel.homePath()
+        if (start.charAt(0) === "~")
+            start = pickerFsModel.homePath() + start.slice(1)
+        root.navigateTo(start)
+        folderList.forceActiveFocus()
+    }
 
     function navigateTo(path) {
         folderList.currentIndex = -1
         currentDir = path
+        // The field starts bound to currentDir, but that binding is dropped on
+        // the first manual edit, so every navigation must refresh it in sync.
+        pathField.text = path
         pickerFsModel.setRootPath(path)
     }
 

--- a/src/qml/components/SettingsPanel.qml
+++ b/src/qml/components/SettingsPanel.qml
@@ -54,6 +54,19 @@ Window {
     // Sort column dropdown: parallel label/value arrays.
     readonly property var sortByLabels: ["Name", "Size", "Modified", "Type"]
     readonly property var sortByValues: ["name", "size", "modified", "type"]
+    readonly property var startupDirLabels: ["Last folder", "Home folder", "Custom folder"]
+    readonly property var startupDirValues: ["last", "home", ""]
+    // Map between the config value ("last"/"home"/an absolute path) and the
+    // dropdown: a path is the "Custom folder" entry, and its text lives in
+    // draftStartupDirCustom while switching folders.
+    function startupDirCustomOf(value) {
+        return (value !== "last" && value !== "home") ? value : ""
+    }
+    function startupDirIndexOf(value) {
+        if (value === "last") return 0
+        if (value === "home") return 1
+        return 2
+    }
 
     property bool currentShowHidden: false
     property bool currentSidebarVisible: true
@@ -81,6 +94,10 @@ Window {
     readonly property var quickAccessNames: ["Home", "Recents", "Trash", "Network", "Pictures", "Downloads"]
     property var draftHiddenQuickAccess: config.hiddenQuickAccess
     property string draftSidebarPosition: config.sidebarPosition
+    // "last" (saved session), "home", or an absolute path from "Custom folder".
+    property string draftStartupDir: config.startupDir
+    property string draftStartupDirCustom: root.startupDirCustomOf(config.startupDir)
+    readonly property int startupDirIndex: root.startupDirIndexOf(root.draftStartupDir)
     property int draftSidebarWidth: currentSidebarWidth
     property int draftRadiusSmall: config.radiusSmall
     property int draftRadiusMedium: config.radiusMedium
@@ -263,6 +280,8 @@ Window {
         draftSidebarVisible = true
         draftHiddenQuickAccess = []
         draftSidebarPosition = defaultSidebarPosition
+        draftStartupDir = "last"
+        draftStartupDirCustom = ""
         draftSidebarWidth = defaultSidebarWidth
         draftRadiusSmall = defaultRadiusSmall
         draftRadiusMedium = defaultRadiusMedium
@@ -308,6 +327,8 @@ Window {
             draftSidebarVisible = currentSidebarVisible
             draftHiddenQuickAccess = config.hiddenQuickAccess
             draftSidebarPosition = config.sidebarPosition
+            draftStartupDir = config.startupDir
+            draftStartupDirCustom = root.startupDirCustomOf(config.startupDir)
             draftSidebarWidth = currentSidebarWidth
             draftRadiusSmall = config.radiusSmall
             draftRadiusMedium = Math.max(config.radiusMedium, draftRadiusSmall)
@@ -379,6 +400,7 @@ Window {
             sidebarVisible: draftSidebarVisible,
             hiddenQuickAccess: draftHiddenQuickAccess,
             sidebarPosition: draftSidebarPosition,
+            startupDir: draftStartupDir,
             sidebarWidth: draftSidebarWidth,
             radiusSmall: draftRadiusSmall,
             radiusMedium: draftRadiusMedium,
@@ -430,6 +452,9 @@ Window {
     }
 
     onClosing: {
+        // Never leave a child dialog "open" behind a closed window: reopening
+        // Settings must not resurrect the folder picker.
+        startupPicker.visible = false
         root.flushPendingChanges()
         root.closed()
     }
@@ -445,10 +470,11 @@ Window {
         onTriggered: root.applyPendingSettings()
     }
 
-    // Close on Escape
+    // Close on Escape. A child dialog owns the Escape shortcut while open, so
+    // Settings stays put and only the dialog closes.
     Shortcut {
         sequence: "Escape"
-        enabled: root.visible
+        enabled: root.visible && !startupPicker.visible
         onActivated: root.closePanel()
     }
 
@@ -655,6 +681,92 @@ Window {
         ColumnLayout {
             width: pageLoader.width
             spacing: 6
+
+            Text {
+                text: "Startup"
+                color: Theme.accent
+                font.pointSize: Theme.fontSmall
+                font.bold: true
+                Layout.bottomMargin: 4
+            }
+
+            Q.Dropdown {
+                Layout.fillWidth: true
+                label: "Open on start"
+                model: root.startupDirLabels
+                currentIndex: root.startupDirIndex
+                onSelected: (index, _) => {
+                    if (index !== 2) {
+                        root.draftStartupDir = root.startupDirValues[index]
+                        root.applySettingsNow()
+                        return
+                    }
+                    // A bare path means "Custom folder". An empty custom value
+                    // keeps the previous behaviour ("last") until one is typed.
+                    root.draftStartupDir = root.draftStartupDirCustom.trim()
+                }
+            }
+
+            RowLayout {
+                visible: root.startupDirIndex === 2
+                Layout.fillWidth: true
+                spacing: Q.Theme.spacingMd
+
+                Text {
+                    text: "Custom folder directory"
+                    color: Theme.subtext
+                    font.pixelSize: Q.Theme.fontSize
+                    Layout.preferredWidth: 140
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 34
+                    Layout.minimumWidth: 120
+                    radius: Q.Theme.radius
+                    border.color: Q.Theme.surface1
+                    color: Q.Theme.surface0
+                    clip: true
+
+                    Text {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: Theme.spacing
+                        anchors.rightMargin: Theme.spacing
+                        text: root.draftStartupDirCustom !== ""
+                            ? root.draftStartupDirCustom : "No folder selected yet"
+                        color: root.draftStartupDirCustom !== "" ? Theme.text : Theme.muted
+                        font.pixelSize: Q.Theme.fontSize
+                        elide: Text.ElideLeft
+                    }
+                }
+
+                Rectangle {
+                    Layout.preferredWidth: 38
+                    Layout.preferredHeight: 34
+                    Layout.leftMargin: -6
+                    radius: Q.Theme.radius
+                    color: mouse.containsMouse ? Qt.lighter(Q.Theme.primary, 1.15) : Q.Theme.primary
+
+                    IconFolder {
+                        anchors.centerIn: parent
+                        size: 16
+                        color: Q.Theme.backgroundDeep
+                    }
+
+                    MouseArea {
+                        id: mouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            startupPicker.startingFolder = root.draftStartupDirCustom
+                            startupPicker.open()
+                        }
+                    }
+                }
+            }
 
             Text {
                 text: "Browsing"
@@ -1300,6 +1412,16 @@ Window {
                 }
 
             }
+        }
+    }
+
+    FolderPickerDialog {
+        id: startupPicker
+        anchors.fill: parent
+        onFolderPicked: (path) => {
+            root.draftStartupDirCustom = path
+            root.draftStartupDir = path
+            root.applySettingsNow()
         }
     }
 }

--- a/src/qml/components/SettingsPanel.qml
+++ b/src/qml/components/SettingsPanel.qml
@@ -701,9 +701,12 @@ Window {
                         root.applySettingsNow()
                         return
                     }
-                    // A bare path means "Custom folder". An empty custom value
-                    // keeps the previous behaviour ("last") until one is typed.
+                    // A bare path means "Custom folder". Apply right away when one is
+                    // already configured; until then an empty value keeps the
+                    // previous behaviour ("last") and the row invites picking.
                     root.draftStartupDir = root.draftStartupDirCustom.trim()
+                    if (root.draftStartupDir !== "")
+                        root.applySettingsNow()
                 }
             }
 

--- a/src/services/configmanager.cpp
+++ b/src/services/configmanager.cpp
@@ -346,8 +346,10 @@ void ConfigManager::loadConfig()
             m_fontFamily = QString::fromStdString(*v);
         if (auto v = config["general"]["default_view"].value<std::string>())
             m_defaultView = QString::fromStdString(*v);
-        if (auto v = config["general"]["startup_dir"].value<std::string>())
-            m_startupDir = QString::fromStdString(*v);
+        if (auto v = config["general"]["startup_dir"].value<std::string>()) {
+            const QString value = QString::fromStdString(*v).trimmed();
+            m_startupDir = value.isEmpty() ? QStringLiteral("last") : value;
+        }
         if (auto v = config["general"]["show_hidden"].value<bool>())
             m_showHidden = *v;
         if (auto v = config["general"]["right_click_to_edit_path"].value<bool>())

--- a/src/services/configmanager.cpp
+++ b/src/services/configmanager.cpp
@@ -278,6 +278,7 @@ void ConfigManager::setDefaults()
     m_iconTheme = "Adwaita";
     m_fontFamily.clear();
     m_defaultView = "grid";
+    m_startupDir = "last";
     m_showHidden = false;
     m_rightClickToEditPath = true;
     m_sortBy = "name";
@@ -345,6 +346,8 @@ void ConfigManager::loadConfig()
             m_fontFamily = QString::fromStdString(*v);
         if (auto v = config["general"]["default_view"].value<std::string>())
             m_defaultView = QString::fromStdString(*v);
+        if (auto v = config["general"]["startup_dir"].value<std::string>())
+            m_startupDir = QString::fromStdString(*v);
         if (auto v = config["general"]["show_hidden"].value<bool>())
             m_showHidden = *v;
         if (auto v = config["general"]["right_click_to_edit_path"].value<bool>())
@@ -598,6 +601,11 @@ remember_sort_per_folder = true
 # Warn at startup when a tool HyprFM uses (gvfs, ffmpeg, bat, pdftoppm…) is missing.
 dependency_startup_check = true
 
+# Folder opened at startup when no path is passed on the command line:
+# "last" = wherever the previous session was, "home" = your home folder, or an
+# absolute path (a leading ~ is expanded). A command line path always wins.
+startup_dir = "last"
+
 [sidebar]
 # "left" | "right"
 position = "left"
@@ -824,6 +832,7 @@ QString ConfigManager::darkTheme() const { return m_darkTheme; }
 QString ConfigManager::iconTheme() const { return m_iconTheme; }
 QString ConfigManager::fontFamily() const { return m_fontFamily; }
 QString ConfigManager::defaultView() const { return m_defaultView; }
+QString ConfigManager::startupDir() const { return m_startupDir; }
 bool ConfigManager::showHidden() const { return m_showHidden; }
 
 bool ConfigManager::rightClickToEditPath() const { return m_rightClickToEditPath; }
@@ -959,6 +968,12 @@ void ConfigManager::saveSettings(const QVariantMap &settings)
     if (settings.contains("fontFamily")) {
         m_fontFamily = settings.value("fontFamily").toString().trimmed();
         general.insert_or_assign("font_family", m_fontFamily.toStdString());
+    }
+
+    if (settings.contains("startupDir")) {
+        const QString value = settings.value("startupDir").toString().trimmed();
+        m_startupDir = value.isEmpty() ? QStringLiteral("last") : value;
+        general.insert_or_assign("startup_dir", m_startupDir.toStdString());
     }
 
     if (settings.contains("showHidden")) {

--- a/src/services/configmanager.h
+++ b/src/services/configmanager.h
@@ -19,6 +19,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(QString iconTheme READ iconTheme NOTIFY configChanged)
     Q_PROPERTY(QString fontFamily READ fontFamily NOTIFY configChanged)
     Q_PROPERTY(QString defaultView READ defaultView NOTIFY configChanged)
+    Q_PROPERTY(QString startupDir READ startupDir NOTIFY configChanged)
     Q_PROPERTY(bool showHidden READ showHidden NOTIFY configChanged)
     Q_PROPERTY(bool rightClickToEditPath READ rightClickToEditPath NOTIFY configChanged)
     Q_PROPERTY(bool dependencyStartupCheck READ dependencyStartupCheck NOTIFY configChanged)
@@ -73,6 +74,8 @@ public:
     QString iconTheme() const;
     QString fontFamily() const;
     QString defaultView() const;
+    // "last" (wherever the previous session was), "home", or an absolute path.
+    QString startupDir() const;
     bool showHidden() const;
     // Right click on the address bar starts path editing (Ctrl+L behaviour).
     // Clicking a breadcrumb segment still navigates.
@@ -165,6 +168,7 @@ private:
     QString m_iconTheme;
     QString m_fontFamily;
     QString m_defaultView;
+    QString m_startupDir;
     bool m_showHidden;
     bool m_rightClickToEditPath;
     bool m_dependencyStartupCheck;

--- a/tests/tst_configmanager.cpp
+++ b/tests/tst_configmanager.cpp
@@ -499,6 +499,15 @@ private slots:
         mgr3.saveSettings(QVariantMap{{"startupDir", ""}});
         ConfigManager mgr4(path);
         QCOMPARE(mgr4.startupDir(), QString("last"));
+
+        // A manual edit that leaves the key empty or whitespace also falls
+        // back on load, mirroring saveSettings().
+        QFile f(path);
+        QVERIFY(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        f.write("[general]\nstartup_dir = \"\"\n");
+        f.close();
+        ConfigManager mgr5(path);
+        QCOMPARE(mgr5.startupDir(), QString("last"));
     }
 
     void testDependencyStartupCheckOptOut()

--- a/tests/tst_configmanager.cpp
+++ b/tests/tst_configmanager.cpp
@@ -479,6 +479,28 @@ private slots:
         QCOMPARE(mgr2.windowButtonLayout(), QString("close:minimize"));
     }
 
+    void testSaveStartupDir()
+    {
+        QTemporaryDir dir;
+        QString path = dir.path() + "/config.toml";
+
+        ConfigManager mgr(path);
+        QCOMPARE(mgr.startupDir(), QString("last"));
+
+        mgr.saveSettings(QVariantMap{{"startupDir", "/home/user/Media"}});
+        ConfigManager mgr2(path);
+        QCOMPARE(mgr2.startupDir(), QString("/home/user/Media"));
+
+        mgr2.saveSettings(QVariantMap{{"startupDir", "home"}});
+        ConfigManager mgr3(path);
+        QCOMPARE(mgr3.startupDir(), QString("home"));
+
+        // An empty value falls back to the default.
+        mgr3.saveSettings(QVariantMap{{"startupDir", ""}});
+        ConfigManager mgr4(path);
+        QCOMPARE(mgr4.startupDir(), QString("last"));
+    }
+
     void testDependencyStartupCheckOptOut()
     {
         QTemporaryDir dir;


### PR DESCRIPTION
## What

Adds a configurable startup directory so HyprFM can stop always reopening
wherever the previous session left off.

Previously the app restores the saved session's tabs on every launch (or opens
the folder passed on the command line). Now a new `[general] startup_dir`
setting controls what happens when no path is given:

- `"last"` — restore the previous session (default, current behaviour)
- `"home"` — open the home folder
- an absolute path — always start there (a leading `~` is expanded)

A folder passed on the command line still always wins. If the configured path
no longer exists, HyprFM falls back to the saved session.

## UI

New "Startup" section in Settings → Layout:

- **Open on start** dropdown (Last folder / Home folder / Custom folder).
- Choosing **Custom folder** reveals a directory field next to a browse button
  that opens a small folder picker dialog. The picker lets you type a path
  directly (supports `~` and relative paths) or browse visually:
  - left click highlights a row, and "Select this folder" picks the highlighted
    folder (or the one being browsed when nothing is highlighted)
  - double-click / Enter descends into a folder
  - clicking empty space or right-clicking clears the highlight
  - the up arrow at the top-left goes up one level

Changes take effect immediately and are stored in `config.toml` like any other
Settings change.

## Implementation notes

- New `startup_dir` key in `ConfigManager` (`Q_PROPERTY`, parse, save, default
  template with a short comment), plus a `testSaveStartupDir` test.
- `main.cpp` applies the override before the session restore when it is
  primary, no CLI path was given, and the configured value is not `"last"`.
- The picker uses its own `FileSystemModel` (`pickerFsModel`) so browsing in
  the dialog never disturbs the file views.

## Testing

- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON`
  + `cmake --build build --parallel` — builds clean.
- `ctest` — tst_configmanager 56/56 pass; the two known environment-dependent
  failures in tst_fileoperations are unrelated (`testTrashHelpersForHomePath`).
- Manually verified: `"last"` restores the session, `"home"` opens home, a
  valid absolute path opens there, and an invalid path falls back to the
  session; custom paths with `~` are expanded.
