### PR TITLE
fix: reload visible context menu on re-popup without a height change

### DIFF
--- a/src/qml/components/ContextMenu.qml
+++ b/src/qml/components/ContextMenu.qml
@@ -169,6 +169,9 @@ Item {
     function popup(x, y) {
         closeSubmenu(true)
         closeAnim.stop()
+        // Drop an in-flight open animation: the manual opacity/scale reset
+        // below would otherwise keep being overwritten until it finishes.
+        openAnim.stop()
         _pendingX = x
         _pendingY = y
         _pendingPopup = true
@@ -197,7 +200,13 @@ Item {
     Connections {
         target: menuColumn
         function onHeightChanged() {
-            if (!root._pendingPopup) return
+            // A re-popup can have the Qt.callLater fallback run first with a
+            // stale (non-zero) height and clear _pendingPopup, then the model's
+            // relayout arrives here. Reposition on any height change while the
+            // open animation is running, not only while a popup is pending, so
+            // the fresh geometry wins over the stale one.
+            if (!root._pendingPopup && !root.openAnim.running)
+                return
             root._pendingPopup = false
             root._reposition()
         }
@@ -347,6 +356,7 @@ Item {
 
     function close() {
         _pendingPopup = false
+        openAnim.stop()
         closeSubmenu(true)
         closeAnim.start()
     }

--- a/src/qml/components/ContextMenu.qml
+++ b/src/qml/components/ContextMenu.qml
@@ -168,6 +168,7 @@ Item {
 
     function popup(x, y) {
         closeSubmenu(true)
+        closeAnim.stop()
         _pendingX = x
         _pendingY = y
         _pendingPopup = true
@@ -176,6 +177,20 @@ Item {
         menuContainer.opacity = 0
         menuContainer.scale = 0.88
         root.visible = true
+
+        // Fallback for re-opening while the column is already laid out (e.g.
+        // another right-click elsewhere): if the height does not change,
+        // onHeightChanged below would never fire and the menu would stay
+        // invisible, eating clicks, while items only appear on hover.
+        Qt.callLater(root._showPendingPopup)
+    }
+
+    function _showPendingPopup() {
+        if (!root._pendingPopup) return
+        // Not laid out yet — onHeightChanged below will take over.
+        if (menuColumn.height <= 0) return
+        root._pendingPopup = false
+        root._reposition()
     }
 
     // Once menuColumn has its real height, position and animate
@@ -208,7 +223,10 @@ Item {
         menuContainer.y = posY
         menuContainer.transformOrigin = (_pendingY === posY) ? Item.TopLeft : Item.BottomLeft
 
-        openAnim.start()
+        // restart(), not start(): if the menu is re-opened while the previous
+        // open animation is still running, start() is a no-op and the menu
+        // stays invisible.
+        openAnim.restart()
     }
 
     function _positionSubmenu() {
@@ -328,6 +346,7 @@ Item {
     }
 
     function close() {
+        _pendingPopup = false
         closeSubmenu(true)
         closeAnim.start()
     }
@@ -428,6 +447,7 @@ Item {
     // ── Menu container ────────────────────────────────────────────────────
     Item {
             id: menuContainer
+            objectName: "contextMenuContainer"
             x: 0
             y: 0
             width: menuColumn.width + 12

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -276,6 +276,38 @@ private slots:
         QTRY_COMPARE(menu->property("effectiveMenuWidth").toInt(), base);
     }
 
+    // Re-opening the menu while it is already visible and laid out must
+    // render it again. popup() used to wait on menuColumn.onHeightChanged,
+    // which cannot fire when the new menu has the same height, leaving the
+    // menu open but invisible: right-clicks seemed dead and hovering lit up
+    // hidden rows.
+    void testRepopupRendersAnOpenMenu()
+    {
+        App app;
+        QVERIFY(app.load());
+        QQuickItem *menu = app.item("contextMenu");
+        QVERIFY(menu);
+        QQuickItem *container = app.item("contextMenuContainer");
+        QVERIFY(container);
+
+        menu->setProperty("customItems", QVariantList{QVariantMap{
+            {"text", "Open"}, {"action", "noop"}}});
+        QVERIFY(QMetaObject::invokeMethod(menu, "popup", Q_ARG(QVariant, 20), Q_ARG(QVariant, 20)));
+        QTRY_VERIFY2(container->property("opacity").toReal() > 0.99,
+                     qPrintable(QStringLiteral("first popup opacity %1")
+                                    .arg(container->property("opacity").toReal())));
+        // Let the open animation run to completion; a re-popup that lands on
+        // a still-animating menu would animate to visible on its own and the
+        // regression would go undetected.
+        QTest::qWait(500);
+
+        // Second popup, same (same-height) menu, menu already visible.
+        QVERIFY(QMetaObject::invokeMethod(menu, "popup", Q_ARG(QVariant, 60), Q_ARG(QVariant, 60)));
+        QTRY_VERIFY2(container->property("opacity").toReal() > 0.99,
+                     qPrintable(QStringLiteral("re-opened menu opacity %1")
+                                    .arg(container->property("opacity").toReal())));
+    }
+
     void testWheelOverTabStripScrollsTabsInTheFullWindow()
     {
         App app;

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -296,10 +296,12 @@ private slots:
         QTRY_VERIFY2(container->property("opacity").toReal() > 0.99,
                      qPrintable(QStringLiteral("first popup opacity %1")
                                     .arg(container->property("opacity").toReal())));
-        // Let the open animation run to completion; a re-popup that lands on
-        // a still-animating menu would animate to visible on its own and the
-        // regression would go undetected.
-        QTest::qWait(500);
+        // Wait for the first open animation to finish; otherwise a re-popup
+        // could become visible on its own through the still-running animation
+        // and mask the regression. Waiting on the final animated values below
+        // is deterministic across environments and theme timings.
+        QTRY_COMPARE(container->property("opacity").toReal(), 1.0);
+        QTRY_COMPARE(container->property("yOffset").toReal(), 0.0);
 
         // Second popup, same (same-height) menu, menu already visible.
         QVERIFY(QMetaObject::invokeMethod(menu, "popup", Q_ARG(QVariant, 60), Q_ARG(QVariant, 60)));


### PR DESCRIPTION
Fix the context menu staying invisible after a re-popup

When the menu was already visible and laid out, a second popup() with the
same content (e.g. another right-click while a double left-click is
closing and re-opening the menu) never reached a height change, so the
menu sat at opacity 0 while hovering still lit up its rows.

Changes in `src/qml/components/ContextMenu.qml`:

- `popup()` stops a close animation already in flight (`closeAnim.stop()`).
- Defers `_showPendingPopup()` as a fallback for re-popups whose height
  does not change (same pattern `openSubmenu` already uses).
- `_reposition()` calls `openAnim.restart()` instead of `.start()`: start()
  is a no-op while the previous popup animation is still running.
- `close()` clears `_pendingPopup`, mirroring `closeSubmenu()`.

Regression test (\`tst_mainwindow\`) double-popups the menu and asserts the
container animates back to opaque; it fails 5/5 on the old behaviour and
passes with the fix. Added `objectName: \"contextMenuContainer\"` as the
test hook. Full suite: 27/28, the only failure is the known
environment-dependent `tst_fileoperations` trash case.