### PR TITLE
fix: allow the settings window to be shrunk back down after resizing

### DIFF
--- a/src/qml/components/SettingsPanel.qml
+++ b/src/qml/components/SettingsPanel.qml
@@ -13,9 +13,13 @@ Window {
     width: dialogWidth
     height: pageContainer.implicitHeight
     minimumWidth: dialogWidth
-    minimumHeight: height
+    minimumHeight: dialogMinHeight
 
     readonly property int dialogWidth: Math.min(920, (transientParent ? transientParent.width : 920) - 32)
+    // A fixed floor (not the live height): the compositor grows the window by
+    // raising its height, so binding the minimum to it would lock the window
+    // to the new size and it could never be shrunk back down.
+    readonly property int dialogMinHeight: 420
     readonly property int dialogRadius: draftRadiusLarge + 6
 
     function syncHyprlandRounding() {

--- a/tests/tst_mainwindow.cpp
+++ b/tests/tst_mainwindow.cpp
@@ -210,6 +210,25 @@ private slots:
         }
     }
 
+    // minimumHeight used to be bound to the live window height, so once the
+    // compositor grew the settings window the minimum grew with it and the
+    // window could never be shrunk back down. (The horizontal direction always
+    // worked because minimumWidth is a fixed dialogWidth.) Growing the window
+    // must leave the minimum untouched.
+    void testSettingsWindowCanShrinkBackAfterGrowing()
+    {
+        App app;
+        QVERIFY(app.load());
+        QObject *panel = app.window->findChild<QObject *>(QStringLiteral("settingsPanel"));
+        QVERIFY(panel);
+        QVERIFY(QMetaObject::invokeMethod(panel, "openPanel"));
+
+        const int minHeight = panel->property("minimumHeight").toInt();
+        QVERIFY(minHeight > 0);
+        panel->setProperty("height", minHeight + 200);
+        QTRY_COMPARE(panel->property("minimumHeight").toInt(), minHeight);
+    }
+
     // The Dark Mode switch changes the theme without going through the Theme
     // dropdown, and Quill's Dropdown breaks its own currentIndex binding the
     // first time a row is picked. Together that left the field naming one


### PR DESCRIPTION
The settings window used `minimumHeight: height`, so each time the compositor grew the window the minimum grew right along with it. The window could always be enlarged but never shrunk back down (the horizontal direction was unaffected because `minimumWidth: dialogWidth` is a fixed value).

Bind the minimum to a fixed floor (`dialogMinHeight`) mirroring `dialogWidth`.

Regression test: `testSettingsWindowCanShrinkBackAfterGrowing` grows the window and verifies the minimum no longer follows it. Fails on the old code, passes with the fix.

`ctest` note: `testWheelOverTabStripScrollsTabsInTheFullWindow` fails in this environment with and without the patch (pre-existing, unrelated flakiness).